### PR TITLE
[Feat/#4] 소셜 로그인/회원가입 구현, 기본 응답 로직 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,17 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+	// OAuth 2.0
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	//JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+	// 시큐리티
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	//Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/corecord/dev/DevApplication.java
+++ b/src/main/java/corecord/dev/DevApplication.java
@@ -2,8 +2,10 @@ package corecord.dev;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class DevApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/corecord/dev/common/base/BaseErrorStatus.java
+++ b/src/main/java/corecord/dev/common/base/BaseErrorStatus.java
@@ -1,0 +1,9 @@
+package corecord.dev.common.base;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseErrorStatus {
+    HttpStatus getHttpStatus();
+    String getCode();
+    String getMessage();
+}

--- a/src/main/java/corecord/dev/common/base/BaseSuccessStatus.java
+++ b/src/main/java/corecord/dev/common/base/BaseSuccessStatus.java
@@ -1,0 +1,9 @@
+package corecord.dev.common.base;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseSuccessStatus {
+    HttpStatus getHttpStatus();
+    String getCode();
+    String getMessage();
+}

--- a/src/main/java/corecord/dev/common/config/SecurityConfig.java
+++ b/src/main/java/corecord/dev/common/config/SecurityConfig.java
@@ -1,0 +1,106 @@
+package corecord.dev.common.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import corecord.dev.common.response.ApiResponse;
+import corecord.dev.common.status.ErrorStatus;
+import corecord.dev.common.util.JwtFilter;
+import corecord.dev.common.util.JwtUtil;
+import corecord.dev.domain.auth.application.OAuthLoginFailureHandler;
+import corecord.dev.domain.auth.application.OAuthLoginSuccessHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.stream.Stream;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+    private final JwtUtil jwtUtil;
+    private final OAuthLoginSuccessHandler oAuthLoginSuccessHandler;
+    private final OAuthLoginFailureHandler oAuthLoginFailureHandler;
+
+    private final String[] swaggerUrls = {"/swagger-ui/**", "/v3/**"};
+    private final String[] authUrls = {"/", "/api/users/register", "/oauth2/authorization/kakao", "/api/token/access-token"};
+    private final String[] allowedUrls = Stream.concat(Arrays.stream(swaggerUrls), Arrays.stream(authUrls))
+            .toArray(String[]::new);
+
+    @Bean
+    CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(Arrays.asList(
+                "http://localhost:3000",
+                "http://localhost:5173",
+                "https://corecord.site",
+                "https://www.corecord.site",
+                "https://corecord.vercel.app"
+        ));
+        config.setAllowedMethods(Collections.singletonList("*"));
+        config.setAllowedHeaders(Collections.singletonList("*"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+
+    @Bean
+    public AuthenticationEntryPoint authenticationEntryPoint() {
+        return (request, response, authException) -> {
+            ObjectMapper mapper = new ObjectMapper();
+            ErrorStatus errorStatus = ErrorStatus.UNAUTHORIZED;
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding("UTF-8");
+            response.setStatus(errorStatus.getHttpStatus().value());
+
+            response.getWriter()
+                    .write(mapper.writeValueAsString(ApiResponse.error(errorStatus)));
+        };
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity httpSecurity, AuthenticationEntryPoint authenticationEntryPoint) throws Exception {
+        httpSecurity
+                .httpBasic(HttpBasicConfigurer::disable)
+                .cors(corsConfigurer -> corsConfigurer.configurationSource(corsConfigurationSource()))
+                .csrf(AbstractHttpConfigurer::disable)
+                .exceptionHandling(exceptionHandlingConfigurer ->
+                        exceptionHandlingConfigurer
+                                .authenticationEntryPoint(authenticationEntryPoint)
+                )
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .requestCache(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authorize ->
+                        authorize
+                                .requestMatchers(allowedUrls).permitAll()
+                                .anyRequest().authenticated()
+                )
+                .oauth2Login(oauth ->
+                        oauth
+                                .successHandler(oAuthLoginSuccessHandler)
+                                .failureHandler(oAuthLoginFailureHandler)
+                )
+                .addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class)
+        ;
+
+        return httpSecurity.build();
+    }
+
+}

--- a/src/main/java/corecord/dev/common/config/WebConfig.java
+++ b/src/main/java/corecord/dev/common/config/WebConfig.java
@@ -1,0 +1,21 @@
+package corecord.dev.common.config;
+
+import corecord.dev.common.web.UserIdArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final UserIdArgumentResolver userIdArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(userIdArgumentResolver);
+    }
+}

--- a/src/main/java/corecord/dev/common/exception/GeneralException.java
+++ b/src/main/java/corecord/dev/common/exception/GeneralException.java
@@ -1,11 +1,14 @@
 package corecord.dev.common.exception;
 
 import corecord.dev.common.status.ErrorStatus;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class GeneralException extends RuntimeException{
     private final ErrorStatus errorStatus;
+
+    public GeneralException(ErrorStatus errorStatus) {
+        super(errorStatus.getMessage());
+        this.errorStatus = errorStatus;
+    }
 }

--- a/src/main/java/corecord/dev/common/exception/GeneralExceptionAdvice.java
+++ b/src/main/java/corecord/dev/common/exception/GeneralExceptionAdvice.java
@@ -2,6 +2,7 @@ package corecord.dev.common.exception;
 
 import corecord.dev.common.response.ApiResponse;
 import corecord.dev.common.status.ErrorStatus;
+import corecord.dev.domain.token.exception.model.TokenException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -12,6 +13,13 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 @Slf4j
 @RestControllerAdvice(annotations = {RestController.class})
 public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
+
+    // TokenException 처리
+    @ExceptionHandler(TokenException.class)
+    public ResponseEntity<ApiResponse<Void>> handleTokenException(TokenException e) {
+        log.warn(">>>>>>>>TokenException: {}", e.getTokenErrorStatus().getMessage());
+        return ApiResponse.error(e.getTokenErrorStatus());
+    }
 
     // GeneralException 처리
     @ExceptionHandler(GeneralException.class)

--- a/src/main/java/corecord/dev/common/exception/GeneralExceptionAdvice.java
+++ b/src/main/java/corecord/dev/common/exception/GeneralExceptionAdvice.java
@@ -1,8 +1,8 @@
 package corecord.dev.common.exception;
 
 import corecord.dev.common.response.ApiResponse;
+import corecord.dev.common.status.ErrorStatus;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,13 +12,19 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 @Slf4j
 @RestControllerAdvice(annotations = {RestController.class})
 public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
-    @ExceptionHandler(value = { GeneralException.class })
-    protected ResponseEntity<ApiResponse<String>> handleException(GeneralException e) {
-        log.error("Handling GeneralException: {}", e.getMessage());
 
-        ApiResponse<String> response = ApiResponse.FailureResponse(e.getErrorStatus());
-        HttpStatus status = e.getErrorStatus() != null ? e.getErrorStatus().getHttpStatus() : HttpStatus.INTERNAL_SERVER_ERROR;
+    // GeneralException 처리
+    @ExceptionHandler(GeneralException.class)
+    public ResponseEntity<ApiResponse<Void>> handleGeneralException(GeneralException e) {
+        log.warn(">>>>>>>>GeneralException: {}", e.getErrorStatus().getMessage());
+        return ApiResponse.error(e.getErrorStatus());
+    }
 
-        return new ResponseEntity<>(response, status);
+    // 기타 모든 예외 처리
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        log.error(">>>>>>>>Internal Server Error: {}", e.getMessage());
+        e.printStackTrace();
+        return ApiResponse.error(ErrorStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/java/corecord/dev/common/response/ApiResponse.java
+++ b/src/main/java/corecord/dev/common/response/ApiResponse.java
@@ -1,34 +1,46 @@
 package corecord.dev.common.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import corecord.dev.common.status.ErrorStatus;
 import corecord.dev.common.status.SuccessStatus;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 
 @Getter
-@AllArgsConstructor
-@JsonPropertyOrder({"code", "result", "message", "data"})
+@RequiredArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "data"})
 public class ApiResponse<T> {
-    private final int statusCode;
-    private final String result;
-    private final String message;
+    @JsonProperty("is_success")
+    private final Boolean isSuccess;  // 성공 여부
+    private final String code;        // 사용자 정의 코드 (e.g., S001, E999)
+    private final String message;     // 응답 메시지
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    private final T data;
+    private final T data;             // 응답 데이터
 
-    public static <T>ApiResponse<T> SuccessResponse(SuccessStatus status, T data){
-        return new ApiResponse<>(status.getCode(), "SUCCESS", status.getMessage(), data);
-    }
-    public static ApiResponse SuccessResponse(SuccessStatus status){
-        return new ApiResponse<>(status.getCode(), "SUCCESS", status.getMessage(), null);
-    }
-
-    public static ApiResponse FailureResponse(int statusCode, String message){
-        return new ApiResponse<>(statusCode, "FAILURE", message, null);
+    // 성공 응답 (데이터 없음)
+    public static <T> ResponseEntity<ApiResponse<T>> success(SuccessStatus successStatus) {
+        ApiResponse<T> response = new ApiResponse<>(true, successStatus.getCode(), successStatus.getMessage(), null);
+        return ResponseEntity.status(successStatus.getHttpStatus()).body(response);
     }
 
-    public static ApiResponse FailureResponse(ErrorStatus errorStatus){
-        return new ApiResponse<>(errorStatus.getCode(), "FAILURE", errorStatus.getMessage(), null);
+    // 성공 응답 (데이터 있음)
+    public static <T> ResponseEntity<ApiResponse<T>> success(SuccessStatus successStatus, T data) {
+        ApiResponse<T> response = new ApiResponse<>(true, successStatus.getCode(), successStatus.getMessage(), data);
+        return ResponseEntity.status(successStatus.getHttpStatus()).body(response);
+    }
+
+    // 에러 응답 (데이터 없음)
+    public static <T> ResponseEntity<ApiResponse<T>> error(ErrorStatus errorStatus) {
+        ApiResponse<T> response = new ApiResponse<>(false, errorStatus.getCode(), errorStatus.getMessage(), null);
+        return ResponseEntity.status(errorStatus.getHttpStatus()).body(response);
+    }
+
+    // 에러 응답 (데이터 있음)
+    public static <T> ResponseEntity<ApiResponse<T>> error(ErrorStatus errorStatus, T data) {
+        ApiResponse<T> response = new ApiResponse<>(false, errorStatus.getCode(), errorStatus.getMessage(), data);
+        return ResponseEntity.status(errorStatus.getHttpStatus()).body(response);
     }
 }

--- a/src/main/java/corecord/dev/common/response/ApiResponse.java
+++ b/src/main/java/corecord/dev/common/response/ApiResponse.java
@@ -3,6 +3,8 @@ package corecord.dev.common.response;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import corecord.dev.common.base.BaseErrorStatus;
+import corecord.dev.common.base.BaseSuccessStatus;
 import corecord.dev.common.status.ErrorStatus;
 import corecord.dev.common.status.SuccessStatus;
 import lombok.Getter;
@@ -21,26 +23,26 @@ public class ApiResponse<T> {
     private final T data;             // 응답 데이터
 
     // 성공 응답 (데이터 없음)
-    public static <T> ResponseEntity<ApiResponse<T>> success(SuccessStatus successStatus) {
-        ApiResponse<T> response = new ApiResponse<>(true, successStatus.getCode(), successStatus.getMessage(), null);
-        return ResponseEntity.status(successStatus.getHttpStatus()).body(response);
+    public static <T> ResponseEntity<ApiResponse<T>> success(BaseSuccessStatus successStatus) {
+        return ResponseEntity.status(successStatus.getHttpStatus())
+                .body(new ApiResponse<>(true, successStatus.getCode(), successStatus.getMessage(), null));
     }
 
     // 성공 응답 (데이터 있음)
-    public static <T> ResponseEntity<ApiResponse<T>> success(SuccessStatus successStatus, T data) {
-        ApiResponse<T> response = new ApiResponse<>(true, successStatus.getCode(), successStatus.getMessage(), data);
-        return ResponseEntity.status(successStatus.getHttpStatus()).body(response);
+    public static <T> ResponseEntity<ApiResponse<T>> success(BaseSuccessStatus successStatus, T data) {
+        return ResponseEntity.status(successStatus.getHttpStatus())
+                .body(new ApiResponse<>(true, successStatus.getCode(), successStatus.getMessage(), data));
     }
 
     // 에러 응답 (데이터 없음)
-    public static <T> ResponseEntity<ApiResponse<T>> error(ErrorStatus errorStatus) {
-        ApiResponse<T> response = new ApiResponse<>(false, errorStatus.getCode(), errorStatus.getMessage(), null);
-        return ResponseEntity.status(errorStatus.getHttpStatus()).body(response);
+    public static <T> ResponseEntity<ApiResponse<T>> error(BaseErrorStatus errorStatus) {
+        return ResponseEntity.status(errorStatus.getHttpStatus())
+                .body(new ApiResponse<>(false, errorStatus.getCode(), errorStatus.getMessage(), null));
     }
 
     // 에러 응답 (데이터 있음)
-    public static <T> ResponseEntity<ApiResponse<T>> error(ErrorStatus errorStatus, T data) {
-        ApiResponse<T> response = new ApiResponse<>(false, errorStatus.getCode(), errorStatus.getMessage(), data);
-        return ResponseEntity.status(errorStatus.getHttpStatus()).body(response);
+    public static <T> ResponseEntity<ApiResponse<T>> error(BaseErrorStatus errorStatus, T data) {
+        return ResponseEntity.status(errorStatus.getHttpStatus())
+                .body(new ApiResponse<>(false, errorStatus.getCode(), errorStatus.getMessage(), data));
     }
 }

--- a/src/main/java/corecord/dev/common/status/ErrorStatus.java
+++ b/src/main/java/corecord/dev/common/status/ErrorStatus.java
@@ -16,10 +16,18 @@ public enum ErrorStatus {
      *  404 : 존재하지 않는 정보에 대한 요청.
      */
 
-    BAD_REQUEST(HttpStatus.BAD_REQUEST, 400, "잘못된 요청입니다");
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "E400", "잘못된 요청입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "E401", "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "E403", "접근 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "E404", "요청한 자원을 찾을 수 없습니다."),
 
+    /**
+     *  Error Code
+     *  500 : 서버 내부 오류
+     */
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E500", "서버 내부 오류입니다.");
 
     private final HttpStatus httpStatus;
-    private final int code;
+    private final String code;
     private final String message;
 }

--- a/src/main/java/corecord/dev/common/status/ErrorStatus.java
+++ b/src/main/java/corecord/dev/common/status/ErrorStatus.java
@@ -1,12 +1,13 @@
 package corecord.dev.common.status;
 
+import corecord.dev.common.base.BaseErrorStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
-public enum ErrorStatus {
+public enum ErrorStatus implements BaseErrorStatus {
 
     /**
      *  Error Code

--- a/src/main/java/corecord/dev/common/status/SuccessStatus.java
+++ b/src/main/java/corecord/dev/common/status/SuccessStatus.java
@@ -8,10 +8,10 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum SuccessStatus {
 
-    SUCCESS(HttpStatus.OK, 200, "응답에 성공했습니다.");
-
+    OK(HttpStatus.OK, "S001", "요청이 성공적으로 처리되었습니다."),
+    CREATED(HttpStatus.CREATED, "S002", "리소스가 성공적으로 생성되었습니다.");
 
     private final HttpStatus httpStatus;
-    private final int code;
+    private final String code;
     private final String message;
 }

--- a/src/main/java/corecord/dev/common/status/SuccessStatus.java
+++ b/src/main/java/corecord/dev/common/status/SuccessStatus.java
@@ -1,13 +1,15 @@
 package corecord.dev.common.status;
 
+import corecord.dev.common.base.BaseSuccessStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
-public enum SuccessStatus {
+public enum SuccessStatus implements BaseSuccessStatus {
 
+    // 전역
     OK(HttpStatus.OK, "S001", "요청이 성공적으로 처리되었습니다."),
     CREATED(HttpStatus.CREATED, "S002", "리소스가 성공적으로 생성되었습니다.");
 

--- a/src/main/java/corecord/dev/common/util/CookieUtil.java
+++ b/src/main/java/corecord/dev/common/util/CookieUtil.java
@@ -1,0 +1,44 @@
+package corecord.dev.common.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CookieUtil {
+    @Value("${jwt.refresh-token.expiration-time}")
+    private long refreshTokenExpirationTime;
+
+    public ResponseCookie createRefreshTokenCookie(String refreshToken) {
+        return ResponseCookie.from("refresh_token", refreshToken)
+                .httpOnly(true)
+                .sameSite("None") // 배포 시 수정
+                .secure(false) // 배포 시 수정
+                .path("/")
+                .maxAge(refreshTokenExpirationTime)
+                .build();
+    }
+
+    public Cookie getCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals("refresh_token")) {
+                    return cookie;
+                }
+            }
+        }
+        return null;
+    }
+
+    public Cookie deleteRefreshTokenCookie() {
+        Cookie cookie = new Cookie("refresh_token", "");
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+        return cookie;
+    }
+}

--- a/src/main/java/corecord/dev/common/util/JwtFilter.java
+++ b/src/main/java/corecord/dev/common/util/JwtFilter.java
@@ -1,0 +1,53 @@
+package corecord.dev.common.util;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
+
+        if (token != null && jwtUtil.isAccessTokenValid(token)) {
+            String userId = jwtUtil.getUserIdFromAcccessToken(token).toString();
+            Authentication authToken = new UsernamePasswordAuthenticationToken(
+                    userId, // principal로 userId 사용
+                    null,  // credentials는 필요 없으므로 null
+                    null   // authorities는 비워둠 (필요한 경우 권한 추가)
+            );
+
+            SecurityContextHolder.getContext().setAuthentication(authToken);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        // 특정 경로는 필터링하지 않도록 설정
+        String path = request.getRequestURI();
+        return path.startsWith("/oauth2/authorization/kakao") || path.startsWith("/api/users/register") || path.startsWith("/api/token/access-token");
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+}
+

--- a/src/main/java/corecord/dev/common/util/JwtUtil.java
+++ b/src/main/java/corecord/dev/common/util/JwtUtil.java
@@ -1,0 +1,151 @@
+package corecord.dev.common.util;
+
+import corecord.dev.domain.token.exception.enums.TokenErrorStatus;
+import corecord.dev.domain.token.exception.model.TokenException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtUtil {
+    @Value("${jwt.secret}")
+    private String SECRET_KEY;
+    @Value("${jwt.register-token.expiration-time}")
+    private long REGISTER_TOKEN_EXPIRATION_TIME;
+    @Value("${jwt.access-token.expiration-time}")
+    private long ACCESS_TOKEN_EXPIRATION_TIME;
+    @Value("${jwt.refresh-token.expiration-time}")
+    private long REFRESH_TOKEN_EXPIRATION_TIME;
+
+    private SecretKey getSigningKey() {
+        byte[] keyBytes = Decoders.BASE64.decode(this.SECRET_KEY);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String generateAccessToken(Long userId) {
+        log.info("액세스 토큰이 발행되었습니다.");
+        return Jwts.builder()
+                .claim("userId", userId.toString())
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRATION_TIME))
+                .signWith(this.getSigningKey())
+                .compact();
+    }
+
+    public String generateRefreshToken(Long userId) {
+        log.info("리프레쉬 토큰이 발행되었습니다.");
+        return Jwts.builder()
+                .claim("userId", userId.toString())
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRATION_TIME))
+                .signWith(this.getSigningKey())
+                .compact();
+    }
+
+
+    public String generateRegisterToken(String providerId) {
+        log.info("레지스터 토큰이 발행되었습니다.");
+        return Jwts.builder()
+                .claim("providerId", providerId)
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + REGISTER_TOKEN_EXPIRATION_TIME))
+                .signWith(this.getSigningKey())
+                .compact();
+    }
+
+    public boolean isAccessTokenValid(String token) {
+        return isTokenValid(token, "userId");
+    }
+
+    public boolean isRegisterTokenValid(String token) {
+        return isTokenValid(token, "providerId");
+    }
+
+    private boolean isTokenValid(String token, String claimKey) {
+        try {
+            var claims = Jwts.parser()
+                    .verifyWith(this.getSigningKey())
+                    .build()
+                    .parseSignedClaims(token);
+
+            // 토큰 만료 여부 확인
+            Date expirationDate = claims.getPayload().getExpiration();
+            if (expirationDate.before(new Date())) {
+                log.warn("토큰이 만료되었습니다.");
+                return false; // 만료된 토큰
+            }
+
+            // 필수 클레임이 있는지 확인
+            String claimValue = claims.getPayload().get(claimKey, String.class);
+            if (claimValue == null || claimValue.isEmpty()) {
+                log.warn("토큰에 {} 클레임이 없습니다.", claimKey);
+                return false; // 필수 클레임이 없는 경우
+            }
+
+            return true; // 유효한 토큰
+        } catch (JwtException e) {
+            log.warn("유효하지 않은 토큰입니다. JWT 예외: {}", e.getMessage());
+            return false;
+        } catch (IllegalArgumentException e) {
+            log.warn("잘못된 토큰 형식입니다. 예외: {}", e.getMessage());
+            return false;
+        }
+    }
+
+
+    public String getTokenFromHeader(String authorizationHeader) {
+        return authorizationHeader.substring(7);
+    }
+
+    public String getProviderIdFromToken(String token) {
+        try {
+            log.info("토큰 파싱");
+            log.info("token: {}", token);
+            return Jwts.parser()
+                    .verifyWith(this.getSigningKey())
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload()
+                    .get("providerId", String.class);
+        } catch (JwtException | IllegalArgumentException e) {
+            log.warn("유효하지 않은 토큰입니다.");
+            throw new TokenException(TokenErrorStatus.INVALID_REGISTER_TOKEN);
+        }
+    }
+
+    public String getUserIdFromAcccessToken(String token) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(this.getSigningKey())
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload()
+                    .get("userId", String.class);
+        } catch (JwtException | IllegalArgumentException e) {
+            log.warn("유효하지 않은 토큰입니다.");
+            throw new TokenException(TokenErrorStatus.INVALID_ACCESS_TOKEN);
+        }
+    }
+
+    public String getUserIdFromRefreshToken(String token) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(this.getSigningKey())
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload()
+                    .get("userId", String.class);
+        } catch (JwtException | IllegalArgumentException e) {
+            log.warn("유효하지 않은 토큰입니다.");
+            throw new TokenException(TokenErrorStatus.INVALID_REFRESH_TOKEN);
+        }
+    }
+}

--- a/src/main/java/corecord/dev/common/web/UserId.java
+++ b/src/main/java/corecord/dev/common/web/UserId.java
@@ -1,0 +1,12 @@
+package corecord.dev.common.web;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UserId {
+
+}

--- a/src/main/java/corecord/dev/common/web/UserIdArgumentResolver.java
+++ b/src/main/java/corecord/dev/common/web/UserIdArgumentResolver.java
@@ -1,0 +1,33 @@
+package corecord.dev.common.web;
+
+import corecord.dev.common.exception.GeneralException;
+import corecord.dev.common.status.ErrorStatus;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class UserIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterAnnotation(UserId.class) != null &&
+                parameter.getParameterType().equals(Long.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null) {
+            throw new GeneralException(ErrorStatus.UNAUTHORIZED);
+        } else {
+            Long userId = Long.valueOf(authentication.getPrincipal().toString());
+            return userId;
+        }
+    }
+}

--- a/src/main/java/corecord/dev/domain/auth/application/OAuthLoginFailureHandler.java
+++ b/src/main/java/corecord/dev/domain/auth/application/OAuthLoginFailureHandler.java
@@ -1,0 +1,24 @@
+package corecord.dev.domain.auth.application;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuthLoginFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        log.error("LOGIN FAILED : {}", exception.getMessage());
+        super.onAuthenticationFailure(request, response, exception);
+    }
+}

--- a/src/main/java/corecord/dev/domain/auth/application/OAuthLoginSuccessHandler.java
+++ b/src/main/java/corecord/dev/domain/auth/application/OAuthLoginSuccessHandler.java
@@ -1,0 +1,77 @@
+package corecord.dev.domain.auth.application;
+
+import corecord.dev.common.util.CookieUtil;
+import corecord.dev.common.util.JwtUtil;
+import corecord.dev.domain.auth.dto.KakaoUserInfo;
+import corecord.dev.domain.auth.dto.OAuth2UserInfo;
+import corecord.dev.domain.token.entity.RefreshToken;
+import corecord.dev.domain.token.repository.RefreshTokenRepository;
+import corecord.dev.domain.user.entity.User;
+import corecord.dev.domain.user.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.util.Optional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+    @Value("${jwt.redirect.access}")
+    private String ACCESS_TOKEN_REDIRECT_URI; // 기존 유저 로그인 시 리다이렉트 URI
+
+    @Value("${jwt.redirect.register}")
+    private String REGISTER_TOKEN_REDIRECT_URI; // 신규 유저 로그인 시 리다이렉트 URI
+
+    private final JwtUtil jwtUtil;
+    private final CookieUtil cookieUtil;
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+        OAuth2AuthenticationToken token = (OAuth2AuthenticationToken) authentication;
+        OAuth2UserInfo oAuth2UserInfo = new KakaoUserInfo(token.getPrincipal().getAttributes());
+
+        String providerId = oAuth2UserInfo.getProviderId();
+        String name = oAuth2UserInfo.getName();
+        log.info("providerId: {}", providerId);
+        log.info("name: {}", name);
+
+        Optional<User> optionalUser = userRepository.findByProviderId(providerId);
+        User user;
+
+        if (optionalUser.isPresent()) {
+            log.info("기존 유저입니다. 액세스 토큰과 리프레쉬 토큰을 발급합니다.");
+            user = optionalUser.get();
+            refreshTokenRepository.deleteByUserId(user.getUserId());
+            String refreshToken = jwtUtil.generateRefreshToken(user.getUserId());
+            RefreshToken newRefreshToken = RefreshToken.builder().userId(user.getUserId()).refreshToken(refreshToken).build();
+            refreshTokenRepository.save(newRefreshToken);
+
+            ResponseCookie cookie = cookieUtil.createRefreshTokenCookie(refreshToken);
+            response.addHeader("Set-Cookie", cookie.toString());
+
+            String accessToken = URLEncoder.encode(jwtUtil.generateAccessToken(user.getUserId()));
+            String redirectURI = String.format(ACCESS_TOKEN_REDIRECT_URI, accessToken);
+            getRedirectStrategy().sendRedirect(request, response, redirectURI);
+        } else {
+            log.info("신규 유저입니다. 레지스터 토큰을 발급합니다.");
+            String registerToken = URLEncoder.encode(jwtUtil.generateRegisterToken(providerId));
+            String redirectURI = String.format(REGISTER_TOKEN_REDIRECT_URI, registerToken);
+            getRedirectStrategy().sendRedirect(request, response, redirectURI);
+        }
+    }
+
+
+}

--- a/src/main/java/corecord/dev/domain/auth/dto/KakaoUserInfo.java
+++ b/src/main/java/corecord/dev/domain/auth/dto/KakaoUserInfo.java
@@ -1,0 +1,21 @@
+package corecord.dev.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+
+import java.util.Map;
+
+@AllArgsConstructor
+public class KakaoUserInfo implements OAuth2UserInfo {
+
+    private Map<String, Object> attributes;
+
+    @Override
+    public String getProviderId() {
+        return attributes.get("id").toString();
+    }
+
+    @Override
+    public String getName() {
+        return (String) ((Map) attributes.get("properties")).get("nickname");
+    }
+}

--- a/src/main/java/corecord/dev/domain/auth/dto/OAuth2UserInfo.java
+++ b/src/main/java/corecord/dev/domain/auth/dto/OAuth2UserInfo.java
@@ -1,0 +1,6 @@
+package corecord.dev.domain.auth.dto;
+
+public interface OAuth2UserInfo {
+    String getProviderId();
+    String getName();
+}

--- a/src/main/java/corecord/dev/domain/controller/UserController.java
+++ b/src/main/java/corecord/dev/domain/controller/UserController.java
@@ -5,6 +5,7 @@ import corecord.dev.common.status.ErrorStatus;
 import corecord.dev.common.status.SuccessStatus;
 import corecord.dev.domain.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -15,14 +16,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
     private final UserService userService;
 
-    @GetMapping()
-    public ApiResponse getSuccess() {
-        return ApiResponse.SuccessResponse(SuccessStatus.SUCCESS, "OK");
+    @GetMapping("/success")
+    public ResponseEntity<ApiResponse<Void>> getSuccess() {
+        return ApiResponse.success(SuccessStatus.OK);
     }
 
     @GetMapping("/fail")
-    public ApiResponse getFailure() {
-        return ApiResponse.FailureResponse(ErrorStatus.BAD_REQUEST);
+    public ResponseEntity<ApiResponse<Void>> getFail() {
+        return ApiResponse.error(ErrorStatus.BAD_REQUEST);
     }
-
 }

--- a/src/main/java/corecord/dev/domain/dto/request/UserRequest.java
+++ b/src/main/java/corecord/dev/domain/dto/request/UserRequest.java
@@ -1,4 +1,0 @@
-package corecord.dev.domain.dto.request;
-
-public class UserRequest {
-}

--- a/src/main/java/corecord/dev/domain/dto/response/UserResponse.java
+++ b/src/main/java/corecord/dev/domain/dto/response/UserResponse.java
@@ -1,4 +1,0 @@
-package corecord.dev.domain.dto.response;
-
-public class UserResponse {
-}

--- a/src/main/java/corecord/dev/domain/token/constant/TokenSuccessStatus.java
+++ b/src/main/java/corecord/dev/domain/token/constant/TokenSuccessStatus.java
@@ -1,0 +1,16 @@
+package corecord.dev.domain.token.constant;
+
+import corecord.dev.common.base.BaseSuccessStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum TokenSuccessStatus implements BaseSuccessStatus {
+    REISSUE_ACCESS_TOKEN_SUCCESS(HttpStatus.CREATED, "S001", "Access Token 재발급 성공입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/corecord/dev/domain/token/controller/TokenController.java
+++ b/src/main/java/corecord/dev/domain/token/controller/TokenController.java
@@ -1,0 +1,29 @@
+package corecord.dev.domain.token.controller;
+
+import corecord.dev.common.response.ApiResponse;
+import corecord.dev.domain.token.constant.TokenSuccessStatus;
+import corecord.dev.domain.token.dto.response.TokenResponse;
+import corecord.dev.domain.token.service.TokenService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/token")
+@RequiredArgsConstructor
+public class TokenController {
+    private final TokenService tokenService;
+
+    @GetMapping("/access-token")
+    public ResponseEntity<ApiResponse<TokenResponse.AccessTokenResponse>> reissueAccessToken(
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) {
+        TokenResponse.AccessTokenResponse accessTokenResponse = tokenService.reissueAccessToken(request, response);
+        return ApiResponse.success(TokenSuccessStatus.REISSUE_ACCESS_TOKEN_SUCCESS, accessTokenResponse);
+    }
+}

--- a/src/main/java/corecord/dev/domain/token/dto/response/TokenResponse.java
+++ b/src/main/java/corecord/dev/domain/token/dto/response/TokenResponse.java
@@ -1,0 +1,13 @@
+package corecord.dev.domain.token.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+public class TokenResponse {
+
+    @Data
+    @Builder
+    public static class AccessTokenResponse {
+        String accessToken;
+    }
+}

--- a/src/main/java/corecord/dev/domain/token/entity/RefreshToken.java
+++ b/src/main/java/corecord/dev/domain/token/entity/RefreshToken.java
@@ -14,4 +14,12 @@ public class RefreshToken {
     @Id
     private String refreshToken;
     private Long userId;
+
+    @Builder
+    public static RefreshToken of(String refreshToken, Long userId) {
+        return RefreshToken.builder()
+                .refreshToken(refreshToken)
+                .userId(userId)
+                .build();
+    }
 }

--- a/src/main/java/corecord/dev/domain/token/entity/RefreshToken.java
+++ b/src/main/java/corecord/dev/domain/token/entity/RefreshToken.java
@@ -1,0 +1,17 @@
+package corecord.dev.domain.token.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@Getter
+@RedisHash(value = "refreshToken", timeToLive = 604800000)
+@AllArgsConstructor
+@Builder
+public class RefreshToken {
+    @Id
+    private String refreshToken;
+    private Long userId;
+}

--- a/src/main/java/corecord/dev/domain/token/exception/enums/TokenErrorStatus.java
+++ b/src/main/java/corecord/dev/domain/token/exception/enums/TokenErrorStatus.java
@@ -1,0 +1,19 @@
+package corecord.dev.domain.token.exception.enums;
+
+import corecord.dev.common.base.BaseErrorStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum TokenErrorStatus implements BaseErrorStatus {
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "E001", "유효하지 않은 액세스 토큰입니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "E002", "유효하지 않은 리프레쉬 토큰입니다."),
+    INVALID_REGISTER_TOKEN(HttpStatus.UNAUTHORIZED, "E003", "유효하지 않은 회원가입 토큰입니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "E004", "해당 유저 ID의 리프레쉬 토큰이 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/corecord/dev/domain/token/exception/model/TokenException.java
+++ b/src/main/java/corecord/dev/domain/token/exception/model/TokenException.java
@@ -1,0 +1,16 @@
+package corecord.dev.domain.token.exception.model;
+
+import corecord.dev.domain.token.exception.enums.TokenErrorStatus;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class TokenException extends RuntimeException {
+    private final TokenErrorStatus tokenErrorStatus;
+
+    @Override
+    public String getMessage() {
+        return tokenErrorStatus.getMessage();
+    }
+}

--- a/src/main/java/corecord/dev/domain/token/repository/RefreshTokenRepository.java
+++ b/src/main/java/corecord/dev/domain/token/repository/RefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package corecord.dev.domain.token.repository;
+
+import corecord.dev.domain.token.entity.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
+    void deleteByUserId(Long userId);
+    Optional<RefreshToken> findByRefreshToken(String refreshToken);
+}

--- a/src/main/java/corecord/dev/domain/token/service/TokenService.java
+++ b/src/main/java/corecord/dev/domain/token/service/TokenService.java
@@ -27,17 +27,18 @@ public class TokenService {
         Cookie cookie = cookieUtil.getCookie(request);
         String refreshToken = cookie.getValue();
         Long userId = Long.parseLong(jwtUtil.getUserIdFromRefreshToken(refreshToken));
-        RefreshToken existRefreshToken = refreshTokenRepository.findByRefreshToken(refreshToken)
-                .orElseThrow(() -> new TokenException(TokenErrorStatus.REFRESH_TOKEN_NOT_FOUND));
-        String newAccessToken;
+        RefreshToken existRefreshToken = getExistRefreshToken(refreshToken);
         if (!existRefreshToken.getRefreshToken().equals(refreshToken) || !(jwtUtil.isAccessTokenValid(refreshToken))) {
             throw new TokenException(TokenErrorStatus.INVALID_REFRESH_TOKEN);
-        } else {
-            newAccessToken = jwtUtil.generateAccessToken(userId);
         }
-
+        String newAccessToken = jwtUtil.generateAccessToken(userId);
         ResponseCookie newCookie = cookieUtil.createRefreshTokenCookie(refreshToken);
         response.addHeader("Set-Cookie", newCookie.toString());
         return TokenResponse.AccessTokenResponse.builder().accessToken(newAccessToken).build();
+    }
+
+    private RefreshToken getExistRefreshToken(String refreshToken) {
+        return refreshTokenRepository.findByRefreshToken(refreshToken)
+                .orElseThrow(() -> new TokenException(TokenErrorStatus.REFRESH_TOKEN_NOT_FOUND));
     }
 }

--- a/src/main/java/corecord/dev/domain/token/service/TokenService.java
+++ b/src/main/java/corecord/dev/domain/token/service/TokenService.java
@@ -1,0 +1,43 @@
+package corecord.dev.domain.token.service;
+
+import corecord.dev.common.util.CookieUtil;
+import corecord.dev.common.util.JwtUtil;
+import corecord.dev.domain.token.dto.response.TokenResponse;
+import corecord.dev.domain.token.entity.RefreshToken;
+import corecord.dev.domain.token.exception.enums.TokenErrorStatus;
+import corecord.dev.domain.token.exception.model.TokenException;
+import corecord.dev.domain.token.repository.RefreshTokenRepository;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtUtil jwtUtil;
+    private final CookieUtil cookieUtil;
+
+    @Transactional
+    public TokenResponse.AccessTokenResponse reissueAccessToken(HttpServletRequest request, HttpServletResponse response) {
+        Cookie cookie = cookieUtil.getCookie(request);
+        String refreshToken = cookie.getValue();
+        Long userId = Long.parseLong(jwtUtil.getUserIdFromRefreshToken(refreshToken));
+        RefreshToken existRefreshToken = refreshTokenRepository.findByRefreshToken(refreshToken)
+                .orElseThrow(() -> new TokenException(TokenErrorStatus.REFRESH_TOKEN_NOT_FOUND));
+        String newAccessToken;
+        if (!existRefreshToken.getRefreshToken().equals(refreshToken) || !(jwtUtil.isAccessTokenValid(refreshToken))) {
+            throw new TokenException(TokenErrorStatus.INVALID_REFRESH_TOKEN);
+        } else {
+            newAccessToken = jwtUtil.generateAccessToken(userId);
+        }
+
+        ResponseCookie newCookie = cookieUtil.createRefreshTokenCookie(refreshToken);
+        response.addHeader("Set-Cookie", newCookie.toString());
+        return TokenResponse.AccessTokenResponse.builder().accessToken(newAccessToken).build();
+    }
+}

--- a/src/main/java/corecord/dev/domain/user/constant/UserSuccessStatus.java
+++ b/src/main/java/corecord/dev/domain/user/constant/UserSuccessStatus.java
@@ -1,0 +1,17 @@
+package corecord.dev.domain.user.constant;
+
+import corecord.dev.common.base.BaseSuccessStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum UserSuccessStatus implements BaseSuccessStatus {
+
+    USER_REGISTER_SUCCESS(HttpStatus.CREATED, "S101", "회원가입이 성공적으로 완료되었습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/corecord/dev/domain/user/controller/UserController.java
+++ b/src/main/java/corecord/dev/domain/user/controller/UserController.java
@@ -1,28 +1,37 @@
 package corecord.dev.domain.user.controller;
 
 import corecord.dev.common.response.ApiResponse;
-import corecord.dev.common.status.ErrorStatus;
 import corecord.dev.common.status.SuccessStatus;
+import corecord.dev.common.web.UserId;
+import corecord.dev.domain.user.constant.UserSuccessStatus;
+import corecord.dev.domain.user.dto.request.UserRequest;
+import corecord.dev.domain.user.dto.response.UserResponse;
 import corecord.dev.domain.user.service.UserService;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1")
+@RequestMapping("/api/users")
 public class UserController {
     private final UserService userService;
 
-    @GetMapping("/success")
-    public ResponseEntity<ApiResponse<Void>> getSuccess() {
-        return ApiResponse.success(SuccessStatus.OK);
+    @GetMapping("/test")
+    public ResponseEntity<ApiResponse<String>> getSuccess(
+            @UserId Long userId
+    ) {
+        return ApiResponse.success(SuccessStatus.OK, "userId: " + userId);
     }
 
-    @GetMapping("/fail")
-    public ResponseEntity<ApiResponse<Void>> getFail() {
-        return ApiResponse.error(ErrorStatus.BAD_REQUEST);
+    @PostMapping("/register")
+    public ResponseEntity<ApiResponse<UserResponse.UserRegisterDto>> registerUser(
+            HttpServletResponse response,
+            @RequestHeader("Authorization") String authorizationHeader,
+            @RequestBody UserRequest.UserRegisterDto request
+            ) {
+        UserResponse.UserRegisterDto registerResponse = userService.registerUser(response, authorizationHeader, request);
+        return ApiResponse.success(UserSuccessStatus.USER_REGISTER_SUCCESS, registerResponse);
     }
 }

--- a/src/main/java/corecord/dev/domain/user/controller/UserController.java
+++ b/src/main/java/corecord/dev/domain/user/controller/UserController.java
@@ -1,9 +1,9 @@
-package corecord.dev.domain.controller;
+package corecord.dev.domain.user.controller;
 
 import corecord.dev.common.response.ApiResponse;
 import corecord.dev.common.status.ErrorStatus;
 import corecord.dev.common.status.SuccessStatus;
-import corecord.dev.domain.service.UserService;
+import corecord.dev.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/corecord/dev/domain/user/converter/UserConverter.java
+++ b/src/main/java/corecord/dev/domain/user/converter/UserConverter.java
@@ -1,12 +1,26 @@
 package corecord.dev.domain.user.converter;
 
+import corecord.dev.domain.user.dto.request.UserRequest;
+import corecord.dev.domain.user.dto.response.UserResponse;
 import corecord.dev.domain.user.entity.User;
 
 public class UserConverter {
 
-    public static User toUser(String name) {
+    public static User toUserEntity(UserRequest.UserRegisterDto request, String providerId) {
         return User.builder()
-                .name(name)
+                .providerId(providerId)
+                .nickName(request.getNickName())
+                .status(request.getStatus())
                 .build();
     }
+
+    public static UserResponse.UserRegisterDto toUserRegisterDto(User user, String accessToken) {
+        return UserResponse.UserRegisterDto.builder()
+                .userId(user.getUserId())
+                .nickname(user.getNickName())
+                .status(user.getStatus())
+                .accessToken(accessToken)
+                .build();
+    }
+
 }

--- a/src/main/java/corecord/dev/domain/user/converter/UserConverter.java
+++ b/src/main/java/corecord/dev/domain/user/converter/UserConverter.java
@@ -1,6 +1,6 @@
-package corecord.dev.domain.converter;
+package corecord.dev.domain.user.converter;
 
-import corecord.dev.domain.entity.User;
+import corecord.dev.domain.user.entity.User;
 
 public class UserConverter {
 

--- a/src/main/java/corecord/dev/domain/user/dto/request/UserRequest.java
+++ b/src/main/java/corecord/dev/domain/user/dto/request/UserRequest.java
@@ -1,4 +1,0 @@
-package corecord.dev.domain.user.dto.request;
-
-public class UserRequest {
-}

--- a/src/main/java/corecord/dev/domain/user/dto/request/UserRequest.java
+++ b/src/main/java/corecord/dev/domain/user/dto/request/UserRequest.java
@@ -1,0 +1,4 @@
+package corecord.dev.domain.user.dto.request;
+
+public class UserRequest {
+}

--- a/src/main/java/corecord/dev/domain/user/dto/request/UserRequest.java
+++ b/src/main/java/corecord/dev/domain/user/dto/request/UserRequest.java
@@ -1,0 +1,11 @@
+package corecord.dev.domain.user.dto.request;
+
+import lombok.Data;
+
+public class UserRequest {
+    @Data
+    public static class UserRegisterDto {
+        private String nickName;
+        private String status;
+    }
+}

--- a/src/main/java/corecord/dev/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/corecord/dev/domain/user/dto/response/UserResponse.java
@@ -1,0 +1,18 @@
+package corecord.dev.domain.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+public class UserResponse {
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    public static class UserRegisterDto {
+        private Long userId;
+        private String nickname;
+        private String status;
+        private String accessToken;
+    }
+}

--- a/src/main/java/corecord/dev/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/corecord/dev/domain/user/dto/response/UserResponse.java
@@ -1,4 +1,0 @@
-package corecord.dev.domain.user.dto.response;
-
-public class UserResponse {
-}

--- a/src/main/java/corecord/dev/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/corecord/dev/domain/user/dto/response/UserResponse.java
@@ -1,0 +1,4 @@
+package corecord.dev.domain.user.dto.response;
+
+public class UserResponse {
+}

--- a/src/main/java/corecord/dev/domain/user/entity/User.java
+++ b/src/main/java/corecord/dev/domain/user/entity/User.java
@@ -1,4 +1,4 @@
-package corecord.dev.domain.entity;
+package corecord.dev.domain.user.entity;
 
 import corecord.dev.common.base.BaseEntity;
 import jakarta.persistence.*;

--- a/src/main/java/corecord/dev/domain/user/entity/User.java
+++ b/src/main/java/corecord/dev/domain/user/entity/User.java
@@ -19,5 +19,11 @@ public class User extends BaseEntity {
     private Long userId;
 
     @Column(nullable = false)
-    private String name;
+    private String providerId;
+
+    @Column(nullable = false)
+    private String nickName;
+
+    @Column(nullable = false)
+    private String status;
 }

--- a/src/main/java/corecord/dev/domain/user/repository/UserRepository.java
+++ b/src/main/java/corecord/dev/domain/user/repository/UserRepository.java
@@ -4,6 +4,9 @@ import corecord.dev.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByProviderId(String providerId);
 }

--- a/src/main/java/corecord/dev/domain/user/repository/UserRepository.java
+++ b/src/main/java/corecord/dev/domain/user/repository/UserRepository.java
@@ -1,6 +1,6 @@
-package corecord.dev.domain.repository;
+package corecord.dev.domain.user.repository;
 
-import corecord.dev.domain.entity.User;
+import corecord.dev.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/corecord/dev/domain/user/service/UserService.java
+++ b/src/main/java/corecord/dev/domain/user/service/UserService.java
@@ -1,13 +1,53 @@
 package corecord.dev.domain.user.service;
 
+import corecord.dev.common.util.CookieUtil;
+import corecord.dev.common.util.JwtUtil;
+import corecord.dev.domain.token.entity.RefreshToken;
+import corecord.dev.domain.token.exception.enums.TokenErrorStatus;
+import corecord.dev.domain.token.exception.model.TokenException;
+import corecord.dev.domain.token.repository.RefreshTokenRepository;
+import corecord.dev.domain.user.converter.UserConverter;
+import corecord.dev.domain.user.dto.request.UserRequest;
+import corecord.dev.domain.user.dto.response.UserResponse;
+import corecord.dev.domain.user.entity.User;
 import corecord.dev.domain.user.repository.UserRepository;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserService {
+    private final JwtUtil jwtUtil;
+    private final CookieUtil cookieUtil;
     private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
 
+    @Transactional
+    public UserResponse.UserRegisterDto registerUser(HttpServletResponse response, String authorizationHeader, UserRequest.UserRegisterDto request) {
+        String registerToken = jwtUtil.getTokenFromHeader(authorizationHeader);
+
+        if(!jwtUtil.isRegisterTokenValid(registerToken)) {
+            throw new TokenException(TokenErrorStatus.INVALID_REGISTER_TOKEN);
+        }
+
+        String providerId = jwtUtil.getProviderIdFromToken(registerToken);
+        User newUser = UserConverter.toUserEntity(request, providerId);
+        User user = userRepository.save(newUser);
+
+        String refreshToken = jwtUtil.generateRefreshToken(user.getUserId());
+        RefreshToken newRefreshToken = RefreshToken.builder().userId(user.getUserId()).refreshToken(refreshToken).build();
+        refreshTokenRepository.save(newRefreshToken);
+
+        ResponseCookie cookie = cookieUtil.createRefreshTokenCookie(refreshToken);
+        response.addHeader("Set-Cookie", cookie.toString());
+
+        String accessToken = jwtUtil.generateAccessToken(user.getUserId());
+        return UserConverter.toUserRegisterDto(user, accessToken);
+    }
 
 }

--- a/src/main/java/corecord/dev/domain/user/service/UserService.java
+++ b/src/main/java/corecord/dev/domain/user/service/UserService.java
@@ -1,6 +1,6 @@
-package corecord.dev.domain.service;
+package corecord.dev.domain.user.service;
 
-import corecord.dev.domain.repository.UserRepository;
+import corecord.dev.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #4 

### 💡 작업내용
- 카카오 소셜 로그인 구현
- 회원가입 구현
- 시큐리티 관련 설정 추가
- 기본 응답 로직 변경

### 📸 스크린샷(선택)
<img width="572" alt="image" src="https://github.com/user-attachments/assets/aaa0227b-9228-4124-a4db-8389de2c93ca">


### 📝 기타
1️⃣ application-secret.yml
- 수정된 application-secret.yml 확인해주세요.(로컬에서 돌릴때는 redis host 부분 localhost로 바꿔서 사용해야 돌아갑니다.)

2️⃣ redis
- elasticache를 연결해서 사용합니다. (프리티어 750시간 무료)

3️⃣ 기본 응답 로직 변경
- 도메인별 exception 처리를 구분해야 어떤 비즈니스 로직에서 에러가 나고 있는지 파악하기 쉬워서 전역 예외처리는 GeneralException에 처리하고, 각 도메인마다 exception 패키지를 만들어서 enum과 model을 생성해서 사용하게 수정했습니다. (Token 패키지 참고)
- is_success, code, message, data 로 응답되도록 설정했습니다. (code의 경우 API 명세서 작성 시 자세하게 작성해야합니다. 현재는 API 작성 전이라서 예시로 넣어둬서 추후 api 명세서 작성후 수정해야합니다.) : 사진 참조
- 응답 방법에 대해서는 UserController, TokenController 참고바랍니다.
- 성공응답의 경우 각 도메인별 constant 패키지를 만들어서 처리하고 있습니다.(더 좋은 디렉토리 구조가 있으면 변경해도 좋아요)

4️⃣ 실제 배포 시 수정해야하는 부분
- 로그인 성공 시 리다이렉트 URL 수정(프론트 배포 url로 설정하면, 프론트가 개발할때 localhost로 못 돌려보기 때문에 현재는 localhost:3000으로 설정해두었습니다.)
- 쿠키 생성 시 보안 속성 설정 : 프론트가 로컬 개발 환경에서 쿠키 주고 받기 가능하게 현재는 보안 속성을 다 풀어놓았습니다.
- application-secret.yml

5️⃣ @ UserId 어노테이션
- 현재 로그인한 user의 UserId는 @ UserId를 통해서 가져올 수 있게 설정해두었습니다. (UserController의 /test 참고)

p.s. 코드가 지저분한 부분이 몇군데 있는데 추후 리팩토링할때 클린 코드로 바꿔보겠습니다. (지금은 일단 돌아가게 짰습니당..ㅎ)