### PR TITLE
[Fix/#18] 로그인 관련 쿠키 도입 및 임시 토큰 발급 로직 추가

### DIFF
--- a/src/main/java/corecord/dev/common/util/CookieUtil.java
+++ b/src/main/java/corecord/dev/common/util/CookieUtil.java
@@ -15,26 +15,13 @@ public class CookieUtil {
     @Value("${jwt.refresh-token.expiration-time}")
     private long refreshTokenExpirationTime;
 
-    @Value("${jwt.register-token.expiration-time}")
-    private long registerTokenExpirationTime;
-
-    @Value("${jwt.access-token.expiration-time}")
-    private long accessTokenExpirationTime;
-
     public ResponseCookie createTokenCookie(String tokenName, String token) {
-        long expirationTime = switch (tokenName) {
-            case "refreshToken" -> refreshTokenExpirationTime;
-            case "registerToken" -> registerTokenExpirationTime;
-            case "accessToken" -> accessTokenExpirationTime;
-            default -> throw new IllegalArgumentException("Unexpected value: " + tokenName);
-        };
-
         return ResponseCookie.from(tokenName, token)
                 .httpOnly(true)
                 .secure(true) // 배포 시 true로 설정
                 .sameSite("None")
                 .path("/")
-                .maxAge(expirationTime / 1000) // maxAge는 초 단위
+                .maxAge(refreshTokenExpirationTime / 1000) // maxAge는 초 단위
                 .build();
     }
 

--- a/src/main/java/corecord/dev/domain/auth/application/OAuthLoginSuccessHandler.java
+++ b/src/main/java/corecord/dev/domain/auth/application/OAuthLoginSuccessHandler.java
@@ -5,7 +5,9 @@ import corecord.dev.common.util.JwtUtil;
 import corecord.dev.domain.auth.dto.KakaoUserInfo;
 import corecord.dev.domain.auth.dto.OAuth2UserInfo;
 import corecord.dev.domain.token.entity.RefreshToken;
+import corecord.dev.domain.token.entity.TmpToken;
 import corecord.dev.domain.token.repository.RefreshTokenRepository;
+import corecord.dev.domain.token.repository.TmpTokenRepository;
 import corecord.dev.domain.user.entity.User;
 import corecord.dev.domain.user.repository.UserRepository;
 import jakarta.servlet.http.HttpServletRequest;
@@ -36,6 +38,7 @@ public class OAuthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHand
     private final CookieUtil cookieUtil;
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final TmpTokenRepository tmpTokenRepository;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
@@ -58,65 +61,34 @@ public class OAuthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHand
 
     // 기존 유저 처리
     private void handleExistingUser(HttpServletRequest request, HttpServletResponse response, User user) throws IOException {
-        log.info("기존 유저입니다. 액세스 토큰과 리프레쉬 토큰을 발급합니다.");
+        log.info("기존 유저입니다. 임시 토큰을 발급합니다.");
+        // 기존 리프레쉬 토큰, 쿠키 삭제
+        deleteByUserId(user.getUserId());
+        response.addCookie(cookieUtil.deleteCookie("refreshToken"));
 
-        // 기존 리프레쉬 토큰 삭제
-        refreshTokenRepository.deleteByUserId(user.getUserId());
+        // 임시 토큰 생성
+        String tmpToken = jwtUtil.generateTmpToken(user.getUserId());
+        tmpTokenRepository.save(TmpToken.of(tmpToken, user.getUserId()));
+        String redirectURI = String.format(ACCESS_TOKEN_REDIRECT_URI, tmpToken);
 
-        // 새로운 리프레쉬 토큰 생성 및 저장
-        String refreshToken = jwtUtil.generateRefreshToken(user.getUserId());
-        saveRefreshToken(user, refreshToken);
-
-        // 기존 쿠키 삭제
-        deleteExistingTokens(response);
-
-        // RefreshToken 쿠키 추가
-        ResponseCookie refreshTokenCookie = cookieUtil.createTokenCookie("refreshToken", refreshToken);
-        response.addHeader("Set-Cookie", refreshTokenCookie.toString());
-
-        // AccessToken 쿠키 추가
-        String accessToken = jwtUtil.generateAccessToken(user.getUserId());
-        ResponseCookie accessTokenCookie = cookieUtil.createTokenCookie("accessToken", accessToken);
-        response.addHeader("Set-Cookie", accessTokenCookie.toString());
-
-        String redirectURI = String.format(ACCESS_TOKEN_REDIRECT_URI, accessToken, refreshToken);
-
-        // 액세스 토큰 리다이렉트
         getRedirectStrategy().sendRedirect(request, response, redirectURI);
     }
 
     // 신규 유저 처리
     private void handleNewUser(HttpServletRequest request, HttpServletResponse response, String providerId) throws IOException {
         log.info("신규 유저입니다. 레지스터 토큰을 발급합니다.");
-
-        // 이미 레지스터 토큰이 있다면 삭제
-        response.addCookie(cookieUtil.deleteCookie("registerToken"));
-
         // 레지스터 토큰 발급
         String registerToken = jwtUtil.generateRegisterToken(providerId);
-
-        // 레지스터 토큰 쿠키 설정
-        ResponseCookie registerTokenCookie = cookieUtil.createTokenCookie("registerToken", registerToken);
-        response.addHeader("Set-Cookie", registerTokenCookie.toString());
-
         String redirectURI = String.format(REGISTER_TOKEN_REDIRECT_URI, registerToken);
-
-        // 레지스터 토큰 리다이렉트
         getRedirectStrategy().sendRedirect(request, response, redirectURI);
     }
 
-    // 리프레쉬 토큰 저장
-    private void saveRefreshToken(User user, String refreshToken) {
-        RefreshToken newRefreshToken = RefreshToken.builder()
-                .userId(user.getUserId())
-                .refreshToken(refreshToken)
-                .build();
-        refreshTokenRepository.save(newRefreshToken);
-    }
-
-    // 기존 토큰 삭제
-    private void deleteExistingTokens(HttpServletResponse response) {
-        response.addCookie(cookieUtil.deleteCookie("accessToken"));
-        response.addCookie(cookieUtil.deleteCookie("refreshToken"));
+    private void deleteByUserId(Long userId) {
+        Iterable<RefreshToken> tokens = refreshTokenRepository.findAll();
+        for (RefreshToken token : tokens) {
+            if (token.getUserId().equals(userId)) {
+                refreshTokenRepository.delete(token);
+            }
+        }
     }
 }

--- a/src/main/java/corecord/dev/domain/token/constant/TokenSuccessStatus.java
+++ b/src/main/java/corecord/dev/domain/token/constant/TokenSuccessStatus.java
@@ -8,8 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum TokenSuccessStatus implements BaseSuccessStatus {
-    SUCCESS_TEST(HttpStatus.OK, "SUCCESS_TEST", "쿠키 발급 테스트 성공입니다."),
-    REISSUE_ACCESS_TOKEN_SUCCESS(HttpStatus.CREATED, "S001", "Access Token 재발급 성공입니다.");
+    ISSUE_TOKENS_SUCCESS(HttpStatus.OK, "S104", "Access Token 및 Refresh Token 발급 성공입니다."),
+    REISSUE_ACCESS_TOKEN_SUCCESS(HttpStatus.CREATED, "S103", "Access Token 재발급 성공입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/corecord/dev/domain/token/controller/TokenController.java
+++ b/src/main/java/corecord/dev/domain/token/controller/TokenController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 public class TokenController {
     private final TokenService tokenService;
 
-    @GetMapping("/access-token")
+    @GetMapping("/reissue")
     public ResponseEntity<ApiResponse<TokenResponse.AccessTokenResponse>> reissueAccessToken(
             HttpServletRequest request,
             HttpServletResponse response
@@ -25,29 +25,12 @@ public class TokenController {
         return ApiResponse.success(TokenSuccessStatus.REISSUE_ACCESS_TOKEN_SUCCESS, accessTokenResponse);
     }
 
-    @GetMapping("/cookie/test")
-    public ResponseEntity<ApiResponse<String>> test(
+    @GetMapping
+    public ResponseEntity<ApiResponse<TokenResponse.AccessTokenResponse>> issueToken(
             HttpServletResponse response,
-            @RequestHeader("registerToken") String registerToken
+            @RequestHeader("tmpToken") String tmpToken
     ) {
-        tokenService.test(response, registerToken);
-        return ApiResponse.success(TokenSuccessStatus.SUCCESS_TEST);
-    }
-
-    @PostMapping("/cookie/test")
-    public ResponseEntity<ApiResponse<String>> testPost(
-            HttpServletResponse response,
-            @RequestBody String registerToken
-    ) {
-        tokenService.test(response, registerToken);
-        return ApiResponse.success(TokenSuccessStatus.SUCCESS_TEST);
-    }
-
-    @GetMapping("/cookie")
-    public ResponseEntity<ApiResponse<String>> testGetCookie(
-            @CookieValue(value = "registerToken", required = false) String tmpRefreshToken
-    ) {
-        System.out.println(tmpRefreshToken);
-        return ApiResponse.success(TokenSuccessStatus.SUCCESS_TEST, tmpRefreshToken);
+        TokenResponse.AccessTokenResponse accessTokenResponse = tokenService.issueTokens(response, tmpToken);
+        return ApiResponse.success(TokenSuccessStatus.ISSUE_TOKENS_SUCCESS, accessTokenResponse);
     }
 }

--- a/src/main/java/corecord/dev/domain/token/entity/TmpToken.java
+++ b/src/main/java/corecord/dev/domain/token/entity/TmpToken.java
@@ -1,0 +1,25 @@
+package corecord.dev.domain.token.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@Getter
+@RedisHash(value = "tmpToken", timeToLive = 3600000)
+@AllArgsConstructor
+@Builder
+public class TmpToken {
+    @Id
+    private String tmpToken;
+    private Long userId;
+
+    @Builder
+    public static TmpToken of(String tmpToken, Long userId) {
+        return TmpToken.builder()
+                .tmpToken(tmpToken)
+                .userId(userId)
+                .build();
+    }
+}

--- a/src/main/java/corecord/dev/domain/token/exception/enums/TokenErrorStatus.java
+++ b/src/main/java/corecord/dev/domain/token/exception/enums/TokenErrorStatus.java
@@ -11,7 +11,9 @@ public enum TokenErrorStatus implements BaseErrorStatus {
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "E0400_ACCESS", "유효하지 않은 액세스 토큰입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "E0400_REFRESH", "유효하지 않은 리프레쉬 토큰입니다."),
     INVALID_REGISTER_TOKEN(HttpStatus.UNAUTHORIZED, "E0400_REGISTER", "유효하지 않은 회원가입 토큰입니다."),
+    INVALID_TMP_TOKEN(HttpStatus.UNAUTHORIZED, "E0400_TMP", "유효하지 않은 임시 토큰입니다."),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "E0404_REFRESH", "해당 유저 ID의 리프레쉬 토큰이 없습니다."),
+    TMP_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "E0404_TMP", "일치하는 임시 토큰이 없습니다."),
     REGISTER_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "E0404_REGISTER", "회원가입 토큰이 없습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/corecord/dev/domain/token/repository/RefreshTokenRepository.java
+++ b/src/main/java/corecord/dev/domain/token/repository/RefreshTokenRepository.java
@@ -6,6 +6,5 @@ import org.springframework.data.repository.CrudRepository;
 import java.util.Optional;
 
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
-    void deleteByUserId(Long userId);
     Optional<RefreshToken> findByRefreshToken(String refreshToken);
 }

--- a/src/main/java/corecord/dev/domain/token/repository/TmpTokenRepository.java
+++ b/src/main/java/corecord/dev/domain/token/repository/TmpTokenRepository.java
@@ -1,0 +1,10 @@
+package corecord.dev.domain.token.repository;
+
+import corecord.dev.domain.token.entity.TmpToken;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.Optional;
+
+public interface TmpTokenRepository extends CrudRepository<TmpToken, String> {
+    Optional<TmpToken> findByTmpToken(String tmpToken);
+}

--- a/src/main/java/corecord/dev/domain/user/controller/UserController.java
+++ b/src/main/java/corecord/dev/domain/user/controller/UserController.java
@@ -29,10 +29,10 @@ public class UserController {
     @PostMapping("/register")
     public ResponseEntity<ApiResponse<UserResponse.UserRegisterDto>> registerUser(
             HttpServletResponse response,
-            HttpServletRequest request,
+            @RequestHeader("registerToken") String registerToken,
             @RequestBody UserRequest.UserRegisterDto userRegisterDto
             ) {
-        UserResponse.UserRegisterDto registerResponse = userService.registerUser(response, request, userRegisterDto);
+        UserResponse.UserRegisterDto registerResponse = userService.registerUser(response, registerToken, userRegisterDto);
         return ApiResponse.success(UserSuccessStatus.USER_REGISTER_SUCCESS, registerResponse);
     }
 }


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #18 

### 💡 작업내용
1. 회원가입 시 사용되는 registerToken 은 리다이렉트 url에 담아서 전달합니다.(url에 담는건 위험하지만 만료시간 짧게 설정하여 보안성 보장)
2. 기존 회원 로그인시 바로 accessToken과 refreshToken을 발급하던 방식에서 임시 토큰(tmpToken) 을 리다이렉트 url에 담아서 전달합니다.(임시 토큰도 마찬가지로 만료시간 짧게 설정)
3. 이 임시 토큰으로 프론트가 "/api/token" API 요청하여 body에 accessToken, 쿠키에 registerToken을 발급받습니다.

### 📸 스크린샷(선택)

### 📝 기타
- 리다이렉트 url 변경으로 application-secret.yml 수정 되었습니다.
- 기존 axios나 fetch 등으로 프론트엔드 요청 시에는 쿠키가 잘 전달되는데, 백엔드에서 카카오 소셜로그인 리다이렉트 url로는 아무리 테스트를 많이 해도 쿠키가 전달되지 않는 문제로 임시 토큰을 도입하였습니다. 참고한 블로그 옆에 첨부합니다.(https://shout-to-my-mae.tistory.com/m/444)
- hotfix로 쿠키 테스트 진행한 코드는 삭제했습니다.
