### PR TITLE
[Feat/#24] MEMO ver. 경험 기록 임시 저장 기능 구현

### DIFF
--- a/src/main/java/corecord/dev/domain/record/constant/RecordSuccessStatus.java
+++ b/src/main/java/corecord/dev/domain/record/constant/RecordSuccessStatus.java
@@ -9,8 +9,11 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum RecordSuccessStatus implements BaseSuccessStatus {
 
-    MEMO_RECORD_CREATE_SUCCESS(HttpStatus.CREATED, "S307", "메모 경험 기록이 성공적으로 완료되었습니다."),
-    MEMO_RECORD_DETAIL_GET_SUCCESS(HttpStatus.OK, "S401", "메모 경험 기록 세부 조회가 성공적으로 완료되었습니다.");
+    MEMO_RECORD_CREATE_SUCCESS(HttpStatus.CREATED, "S404", "메모 경험 기록이 성공적으로 완료되었습니다."),
+    MEMO_RECORD_DETAIL_GET_SUCCESS(HttpStatus.OK, "S401", "메모 경험 기록 세부 조회가 성공적으로 완료되었습니다."),
+    MEMO_RECORD_TMP_CREATE_SUCCESS(HttpStatus.OK, "S403", "메모 경험 기록 임시 저장이 성공적으로 완료되었습니다."),
+    MEMO_RECORD_TMP_GET_SUCCESS(HttpStatus.OK, "S402", "메모 경험 기록 임시 저장 내역 조회가 성공적으로 완료되었습니다.")
+            ;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/corecord/dev/domain/record/controller/RecordController.java
+++ b/src/main/java/corecord/dev/domain/record/controller/RecordController.java
@@ -33,4 +33,22 @@ public class RecordController {
         RecordResponse.MemoRecordDto recordResponse = recordService.getMemoRecordDetail(userId, recordId);
         return ApiResponse.success(RecordSuccessStatus.MEMO_RECORD_DETAIL_GET_SUCCESS, recordResponse);
     }
+
+    @PostMapping("/memo/tmp")
+    public ResponseEntity<ApiResponse<String>> saveTmpMemoRecord(
+            @UserId Long userId,
+            @RequestBody RecordRequest.TmpMemoRecordDto tmpMemoRecordDto
+    ) {
+        recordService.createTmpMemoRecord(userId, tmpMemoRecordDto);
+        return ApiResponse.success(RecordSuccessStatus.MEMO_RECORD_TMP_CREATE_SUCCESS);
+    }
+
+    @GetMapping("/memo/tmp")
+    public ResponseEntity<ApiResponse<RecordResponse.TmpMemoRecordDto>> getTmpMemoRecord(
+            @UserId Long userId
+    ) {
+        RecordResponse.TmpMemoRecordDto recordResponse = recordService.getTmpMemoRecord(userId);
+        return ApiResponse.success(RecordSuccessStatus.MEMO_RECORD_TMP_GET_SUCCESS, recordResponse);
+    }
+
 }

--- a/src/main/java/corecord/dev/domain/record/converter/RecordConverter.java
+++ b/src/main/java/corecord/dev/domain/record/converter/RecordConverter.java
@@ -26,4 +26,20 @@ public class RecordConverter {
                 .createdAt(record.getCreatedAtFormatted())
                 .build();
     }
+
+    public static RecordResponse.TmpMemoRecordDto toExistingTmpMemoRecordDto(Record record) {
+        return RecordResponse.TmpMemoRecordDto.builder()
+                .isExist(true)
+                .title(record.getTitle())
+                .content(record.getContent())
+                .build();
+    }
+
+    public static RecordResponse.TmpMemoRecordDto toNotExistingTmpMemoRecordDto() {
+        return RecordResponse.TmpMemoRecordDto.builder()
+                .isExist(false)
+                .title(null)
+                .content(null)
+                .build();
+    }
 }

--- a/src/main/java/corecord/dev/domain/record/dto/request/RecordRequest.java
+++ b/src/main/java/corecord/dev/domain/record/dto/request/RecordRequest.java
@@ -13,4 +13,11 @@ public class RecordRequest {
         @NotBlank(message = "저장할 폴더의 id를 입력해주세요.")
         private Long folderId;
     }
+
+    @Data
+    public static class TmpMemoRecordDto {
+        private String title;
+        @NotBlank(message = "임시 저장할 내용을 입력해주세요.")
+        private String content;
+    }
 }

--- a/src/main/java/corecord/dev/domain/record/dto/response/RecordResponse.java
+++ b/src/main/java/corecord/dev/domain/record/dto/response/RecordResponse.java
@@ -18,4 +18,13 @@ public class RecordResponse {
         private String createdAt;
     }
 
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @Data
+    public static class TmpMemoRecordDto {
+        private Boolean isExist;
+        private String title;
+        private String content;
+    }
 }

--- a/src/main/java/corecord/dev/domain/record/exception/enums/RecordErrorStatus.java
+++ b/src/main/java/corecord/dev/domain/record/exception/enums/RecordErrorStatus.java
@@ -11,7 +11,8 @@ public enum RecordErrorStatus implements BaseErrorStatus {
     OVERFLOW_MEMO_RECORD_TITLE(HttpStatus.BAD_REQUEST, "E0400_OVERFLOW_TITLE", "메모 제목은 15자 이내여야 합니다."),
     OVERFLOW_MEMO_RECORD_CONTENT(HttpStatus.BAD_REQUEST, "E0400_OVERFLOW_CONTENT", "메모 내용은 500자 이내여야 합니다."),
     USER_RECORD_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "E401_RECORD_UNAUTHORIZED", "유저가 경험 기록에 대한 권한이 없습니다."),
-    RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "E0404_RECORD", "존재하지 않는 경험 기록입니다.")
+    RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "E0404_RECORD", "존재하지 않는 경험 기록입니다."),
+    ALREADY_TMP_MEMO(HttpStatus.BAD_REQUEST, "E0400_TMP_MEMO", "유저가 이미 임시 저장된 메모를 가지고 있습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/corecord/dev/domain/user/entity/User.java
+++ b/src/main/java/corecord/dev/domain/user/entity/User.java
@@ -51,4 +51,11 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Folder> folders;
 
+    public void updateTmpMemo(Long tmpMemo) {
+        this.tmpMemo = tmpMemo;
+    }
+
+    public void deleteTmpMemo(){
+        this.tmpMemo = null;
+    }
 }


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #24 

### 💡 작업내용
- MEMO ver. 경험 기록 임시 저장 기능 구현
  - `user.tmpMemo` 필드가 null이 아니라면, 이미 임시 저장본이 있음으로 간주하고 exception
  - `title`, `content`를 requestBody로 받아 Record 객체 생성 및 저장
  - 해당 `recordId`를 User의 `tmpMemo` 필드에 저장 
  - `title` 필드는 nullable
- MEMO ver. 경험 기록 임시 저장 내역 조회 기능 구현
  - user의 `tmpMemo`가 null이라면, `isExist = false` 반환
  - null이 아니라면 Record 정보 조회
  - `isExist = true` 및 Record 객체의 `title`, `content` 정보 반환
  - 해당 Record 객체 제거 및 `User.tmpMemo` 필드 초기화 

### 📸 스크린샷(선택)
<img width="555" alt="스크린샷 2024-10-29 오전 2 07 30" src="https://github.com/user-attachments/assets/0bffef1c-e4ae-4c9d-be5b-539976af1125">
<img width="581" alt="스크린샷 2024-10-29 오전 2 08 27" src="https://github.com/user-attachments/assets/78603301-8c6b-4cb8-a008-beacc64e3a06">
<img width="628" alt="스크린샷 2024-10-29 오전 2 09 21" src="https://github.com/user-attachments/assets/f2637a08-b1ea-44eb-b451-3fea89463433">


### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
