### PR TITLE
[Feat/#31] 경험 기록 리스트 조회 기능 구현

### DIFF
--- a/src/main/java/corecord/dev/domain/analysis/entity/Ability.java
+++ b/src/main/java/corecord/dev/domain/analysis/entity/Ability.java
@@ -32,7 +32,7 @@ public class Ability extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "analysis_id", nullable = false)
     private Analysis analysis;
 

--- a/src/main/java/corecord/dev/domain/analysis/entity/Analysis.java
+++ b/src/main/java/corecord/dev/domain/analysis/entity/Analysis.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 
 import java.util.List;
 
@@ -29,6 +30,7 @@ public class Analysis extends BaseEntity {
     @JoinColumn(name = "record_id", nullable = false)
     private Record record;
 
+    @BatchSize(size = 3)
     @OneToMany(mappedBy = "analysis", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<Ability> abilityList;
 }

--- a/src/main/java/corecord/dev/domain/folder/repository/FolderRepository.java
+++ b/src/main/java/corecord/dev/domain/folder/repository/FolderRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface FolderRepository extends JpaRepository<Folder, Long> {
@@ -18,6 +19,13 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
             "WHERE f.user = :user " +
             "ORDER BY f.createdAt desc ")
     List<FolderResponse.FolderDto> findFolderDtoList(@Param(value = "user") User user);
+
+    @Query("SELECT f " +
+            "FROM Folder f " +
+            "WHERE f.title = :title AND f.user = :user ")
+    Optional<Folder> findFolderByTitle(
+            @Param(value = "title") String title,
+            @Param(value = "user") User user);
 
     boolean existsByTitle(String title);
 }

--- a/src/main/java/corecord/dev/domain/record/constant/RecordSuccessStatus.java
+++ b/src/main/java/corecord/dev/domain/record/constant/RecordSuccessStatus.java
@@ -13,7 +13,8 @@ public enum RecordSuccessStatus implements BaseSuccessStatus {
     MEMO_RECORD_DETAIL_GET_SUCCESS(HttpStatus.OK, "S401", "메모 경험 기록 세부 조회가 성공적으로 완료되었습니다."),
     MEMO_RECORD_TMP_CREATE_SUCCESS(HttpStatus.OK, "S403", "메모 경험 기록 임시 저장이 성공적으로 완료되었습니다."),
     MEMO_RECORD_TMP_GET_SUCCESS(HttpStatus.OK, "S402", "메모 경험 기록 임시 저장 내역 조회가 성공적으로 완료되었습니다."),
-    RECORD_LIST_GET_SUCCESS(HttpStatus.OK, "S602", "폴더별 경험 기록 리스트 조회가 성공적으로 완료되었습니다.")
+    RECORD_LIST_GET_SUCCESS(HttpStatus.OK, "S602", "폴더별 경험 기록 리스트 조회가 성공적으로 완료되었습니다."),
+    KEYWORD_RECORD_LIST_GET_SUCCESS(HttpStatus.OK, "S503", "역량 키워드별 경험 기록 리스트 조회가 성공적으로 완료되었습니다.")
             ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/corecord/dev/domain/record/constant/RecordSuccessStatus.java
+++ b/src/main/java/corecord/dev/domain/record/constant/RecordSuccessStatus.java
@@ -12,7 +12,8 @@ public enum RecordSuccessStatus implements BaseSuccessStatus {
     MEMO_RECORD_CREATE_SUCCESS(HttpStatus.CREATED, "S404", "메모 경험 기록이 성공적으로 완료되었습니다."),
     MEMO_RECORD_DETAIL_GET_SUCCESS(HttpStatus.OK, "S401", "메모 경험 기록 세부 조회가 성공적으로 완료되었습니다."),
     MEMO_RECORD_TMP_CREATE_SUCCESS(HttpStatus.OK, "S403", "메모 경험 기록 임시 저장이 성공적으로 완료되었습니다."),
-    MEMO_RECORD_TMP_GET_SUCCESS(HttpStatus.OK, "S402", "메모 경험 기록 임시 저장 내역 조회가 성공적으로 완료되었습니다.")
+    MEMO_RECORD_TMP_GET_SUCCESS(HttpStatus.OK, "S402", "메모 경험 기록 임시 저장 내역 조회가 성공적으로 완료되었습니다."),
+    RECORD_LIST_GET_SUCCESS(HttpStatus.OK, "S602", "폴더별 경험 기록 리스트 조회가 성공적으로 완료되었습니다.")
             ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/corecord/dev/domain/record/controller/RecordController.java
+++ b/src/main/java/corecord/dev/domain/record/controller/RecordController.java
@@ -52,12 +52,21 @@ public class RecordController {
     }
 
     @GetMapping("")
-    public ResponseEntity<ApiResponse<RecordResponse.RecordListDto>> getRecordList(
+    public ResponseEntity<ApiResponse<RecordResponse.RecordListDto>> getRecordListByFolder(
         @UserId Long userId,
         @RequestParam(name = "folder", defaultValue = "all") String folder
     ) {
         RecordResponse.RecordListDto recordResponse = recordService.getRecordList(userId, folder);
         return ApiResponse.success(RecordSuccessStatus.RECORD_LIST_GET_SUCCESS, recordResponse);
+    }
+
+    @GetMapping("/keyword")
+    public ResponseEntity<ApiResponse<RecordResponse.KeywordRecordListDto>> getRecordListByKeyword(
+            @UserId Long userId,
+            @RequestParam(name = "keyword") String keyword
+    ) {
+        RecordResponse.KeywordRecordListDto recordResponse = recordService.getKeywordRecordList(userId, keyword);
+        return ApiResponse.success(RecordSuccessStatus.KEYWORD_RECORD_LIST_GET_SUCCESS, recordResponse);
     }
 
 }

--- a/src/main/java/corecord/dev/domain/record/controller/RecordController.java
+++ b/src/main/java/corecord/dev/domain/record/controller/RecordController.java
@@ -51,4 +51,13 @@ public class RecordController {
         return ApiResponse.success(RecordSuccessStatus.MEMO_RECORD_TMP_GET_SUCCESS, recordResponse);
     }
 
+    @GetMapping("")
+    public ResponseEntity<ApiResponse<RecordResponse.RecordListDto>> getRecordList(
+        @UserId Long userId,
+        @RequestParam(name = "folder", defaultValue = "all") String folder
+    ) {
+        RecordResponse.RecordListDto recordResponse = recordService.getRecordList(userId, folder);
+        return ApiResponse.success(RecordSuccessStatus.RECORD_LIST_GET_SUCCESS, recordResponse);
+    }
+
 }

--- a/src/main/java/corecord/dev/domain/record/converter/RecordConverter.java
+++ b/src/main/java/corecord/dev/domain/record/converter/RecordConverter.java
@@ -55,6 +55,7 @@ public class RecordConverter {
 
         return RecordResponse.RecordDto.builder()
                 .recordId(record.getRecordId())
+                .folder(record.getFolder().getTitle())
                 .title(record.getTitle())
                 .keywordList(keywordList)
                 .createdAt(record.getCreatedAtFormatted())

--- a/src/main/java/corecord/dev/domain/record/converter/RecordConverter.java
+++ b/src/main/java/corecord/dev/domain/record/converter/RecordConverter.java
@@ -54,7 +54,7 @@ public class RecordConverter {
                 .toList();
 
         return RecordResponse.RecordDto.builder()
-                .recordId(record.getRecordId())
+                .analysisId(record.getAnalysis().getAnalysisId())
                 .folder(record.getFolder().getTitle())
                 .title(record.getTitle())
                 .keywordList(keywordList)
@@ -70,6 +70,29 @@ public class RecordConverter {
         return RecordResponse.RecordListDto.builder()
                 .folder(folder)
                 .recordDtoList(recordDtoList)
+                .build();
+    }
+
+    public static RecordResponse.KeywordRecordDto toKeywordRecordDto(Record record) {
+        String content = record.getContent();
+        String truncatedContent = content.length() > 30 ? content.substring(0, 30) : content;
+
+        return RecordResponse.KeywordRecordDto.builder()
+                .analysisId(record.getAnalysis().getAnalysisId())
+                .folder(record.getFolder().getTitle())
+                .title(record.getTitle())
+                .content(truncatedContent)
+                .createdAt(record.getCreatedAtFormatted())
+                .build();
+    }
+
+    public static RecordResponse.KeywordRecordListDto toKeywordRecordListDto(List<Record> recordList) {
+        List<RecordResponse.KeywordRecordDto> keywordRecordDtoList = recordList.stream()
+                .map(RecordConverter::toKeywordRecordDto)
+                .toList();
+
+        return RecordResponse.KeywordRecordListDto.builder()
+                .recordDtoList(keywordRecordDtoList)
                 .build();
     }
 }

--- a/src/main/java/corecord/dev/domain/record/converter/RecordConverter.java
+++ b/src/main/java/corecord/dev/domain/record/converter/RecordConverter.java
@@ -1,10 +1,14 @@
 package corecord.dev.domain.record.converter;
 
+import corecord.dev.domain.analysis.constant.Keyword;
+import corecord.dev.domain.analysis.entity.Ability;
 import corecord.dev.domain.folder.entity.Folder;
 import corecord.dev.domain.record.constant.RecordType;
 import corecord.dev.domain.record.dto.response.RecordResponse;
 import corecord.dev.domain.record.entity.Record;
 import corecord.dev.domain.user.entity.User;
+
+import java.util.List;
 
 public class RecordConverter {
     public static Record toMemoRecordEntity(String title, String content, User user, Folder folder) {
@@ -40,6 +44,31 @@ public class RecordConverter {
                 .isExist(false)
                 .title(null)
                 .content(null)
+                .build();
+    }
+
+    public static RecordResponse.RecordDto toRecordDto(Record record) {
+        List<String> keywordList = record.getAnalysis().getAbilityList().stream()
+                .map(Ability::getKeyword)
+                .map(Keyword::getValue)
+                .toList();
+
+        return RecordResponse.RecordDto.builder()
+                .recordId(record.getRecordId())
+                .title(record.getTitle())
+                .keywordList(keywordList)
+                .createdAt(record.getCreatedAtFormatted())
+                .build();
+    }
+
+    public static RecordResponse.RecordListDto toRecordListDto(String folder, List<Record> recordList) {
+        List<RecordResponse.RecordDto> recordDtoList = recordList.stream()
+                .map(RecordConverter::toRecordDto)
+                .toList();
+
+        return RecordResponse.RecordListDto.builder()
+                .folder(folder)
+                .recordDtoList(recordDtoList)
                 .build();
     }
 }

--- a/src/main/java/corecord/dev/domain/record/dto/response/RecordResponse.java
+++ b/src/main/java/corecord/dev/domain/record/dto/response/RecordResponse.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
 
+import java.util.List;
+
 public class RecordResponse {
     @Builder
     @Getter
@@ -26,5 +28,25 @@ public class RecordResponse {
         private Boolean isExist;
         private String title;
         private String content;
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @Data
+    public static class RecordDto {
+        private Long recordId;
+        private String title;
+        private List<String> keywordList;
+        private String createdAt;
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @Data
+    public static class RecordListDto {
+        private String folder;
+        private List<RecordDto> recordDtoList;
     }
 }

--- a/src/main/java/corecord/dev/domain/record/dto/response/RecordResponse.java
+++ b/src/main/java/corecord/dev/domain/record/dto/response/RecordResponse.java
@@ -36,6 +36,7 @@ public class RecordResponse {
     @Data
     public static class RecordDto {
         private Long recordId;
+        private String folder;
         private String title;
         private List<String> keywordList;
         private String createdAt;

--- a/src/main/java/corecord/dev/domain/record/dto/response/RecordResponse.java
+++ b/src/main/java/corecord/dev/domain/record/dto/response/RecordResponse.java
@@ -35,7 +35,7 @@ public class RecordResponse {
     @AllArgsConstructor
     @Data
     public static class RecordDto {
-        private Long recordId;
+        private Long analysisId;
         private String folder;
         private String title;
         private List<String> keywordList;
@@ -49,5 +49,25 @@ public class RecordResponse {
     public static class RecordListDto {
         private String folder;
         private List<RecordDto> recordDtoList;
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @Data
+    public static class KeywordRecordDto {
+        private Long analysisId;
+        private String folder;
+        private String title;
+        private String content;
+        private String createdAt;
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @Data
+    public static class KeywordRecordListDto {
+        private List<KeywordRecordDto> recordDtoList;
     }
 }

--- a/src/main/java/corecord/dev/domain/record/entity/Record.java
+++ b/src/main/java/corecord/dev/domain/record/entity/Record.java
@@ -40,11 +40,11 @@ public class Record extends BaseEntity {
     @JoinColumn(name = "chat_room_id", nullable = true)
     private ChatRoom chatRoom;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "folder_id", nullable = true)
     private Folder folder;
 
-    @OneToOne(mappedBy = "record", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToOne(mappedBy = "record", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private Analysis analysis;
 
     public void updateContent(String content) {

--- a/src/main/java/corecord/dev/domain/record/repository/RecordRepository.java
+++ b/src/main/java/corecord/dev/domain/record/repository/RecordRepository.java
@@ -1,9 +1,31 @@
 package corecord.dev.domain.record.repository;
 
+import corecord.dev.domain.folder.entity.Folder;
 import corecord.dev.domain.record.entity.Record;
+import corecord.dev.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface RecordRepository extends JpaRepository<Record, Long> {
+
+    @Query("SELECT r " +
+            "FROM Record r " +
+            "WHERE r.user = :user " +
+            "AND r.folder is not null AND r.folder = :folder "+
+            "ORDER BY r.createdAt desc ")
+    List<Record> findRecordsByFolder(
+            @Param(value = "folder") Folder folder,
+            @Param(value = "user") User user);
+
+    @Query("SELECT r " +
+            "FROM Record r " +
+            "WHERE r.user = :user " +
+            "AND r.folder is not null "+
+            "ORDER BY r.createdAt desc ")
+    List<Record> findRecords(@Param(value = "user") User user);
 }

--- a/src/main/java/corecord/dev/domain/record/repository/RecordRepository.java
+++ b/src/main/java/corecord/dev/domain/record/repository/RecordRepository.java
@@ -3,6 +3,7 @@ package corecord.dev.domain.record.repository;
 import corecord.dev.domain.folder.entity.Folder;
 import corecord.dev.domain.record.entity.Record;
 import corecord.dev.domain.user.entity.User;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,17 +16,20 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
 
     @Query("SELECT r " +
             "FROM Record r " +
+            "JOIN FETCH r.analysis a " +
+            "JOIN FETCH a.abilityList al " +
             "WHERE r.user = :user " +
-            "AND r.folder is not null AND r.folder = :folder "+
-            "ORDER BY r.createdAt desc ")
+            "AND r.folder is not null AND r.folder = :folder "+ // 임시 저장 기록 제외
+            "ORDER BY r.createdAt desc ") // 최근 생성 순 정렬
     List<Record> findRecordsByFolder(
             @Param(value = "folder") Folder folder,
             @Param(value = "user") User user);
 
-    @Query("SELECT r " +
-            "FROM Record r " +
+    @Query("SELECT r FROM Record r " +
+            "JOIN FETCH r.analysis a " +
+            "JOIN FETCH a.abilityList al " +
             "WHERE r.user = :user " +
-            "AND r.folder is not null "+
-            "ORDER BY r.createdAt desc ")
+            "AND r.folder is not null " + // 임시 저장 기록 제외
+            "ORDER BY r.createdAt DESC") // 최근 생성 순 정렬
     List<Record> findRecords(@Param(value = "user") User user);
 }

--- a/src/main/java/corecord/dev/domain/record/repository/RecordRepository.java
+++ b/src/main/java/corecord/dev/domain/record/repository/RecordRepository.java
@@ -3,7 +3,6 @@ package corecord.dev.domain.record.repository;
 import corecord.dev.domain.folder.entity.Folder;
 import corecord.dev.domain.record.entity.Record;
 import corecord.dev.domain.user.entity.User;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,6 +16,7 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
     @Query("SELECT r " +
             "FROM Record r " +
             "JOIN FETCH r.analysis a " +
+            "JOIN FETCH r.folder f " +
             "JOIN FETCH a.abilityList al " +
             "WHERE r.user = :user " +
             "AND r.folder is not null AND r.folder = :folder "+ // 임시 저장 기록 제외
@@ -27,6 +27,7 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
 
     @Query("SELECT r FROM Record r " +
             "JOIN FETCH r.analysis a " +
+            "JOIN FETCH r.folder f " +
             "JOIN FETCH a.abilityList al " +
             "WHERE r.user = :user " +
             "AND r.folder is not null " + // 임시 저장 기록 제외

--- a/src/main/java/corecord/dev/domain/record/repository/RecordRepository.java
+++ b/src/main/java/corecord/dev/domain/record/repository/RecordRepository.java
@@ -1,5 +1,6 @@
 package corecord.dev.domain.record.repository;
 
+import corecord.dev.domain.analysis.constant.Keyword;
 import corecord.dev.domain.folder.entity.Folder;
 import corecord.dev.domain.record.entity.Record;
 import corecord.dev.domain.user.entity.User;
@@ -33,4 +34,17 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
             "AND r.folder is not null " + // 임시 저장 기록 제외
             "ORDER BY r.createdAt DESC") // 최근 생성 순 정렬
     List<Record> findRecords(@Param(value = "user") User user);
+
+
+    @Query("SELECT r FROM Ability a " +
+            "JOIN a.analysis an " +
+            "JOIN an.record r " +
+            "JOIN FETCH r.folder f " +
+            "WHERE a.user = :user " +
+            "AND a.keyword = :keyword " +
+            "AND r.folder is not null " + // 임시 저장 기록 제외
+            "ORDER BY r.createdAt DESC") // 최근 생성 순 정렬
+    List<Record> findRecordByKeyword(
+            @Param(value = "keyword")Keyword keyword,
+            @Param(value = "user") User user);
 }

--- a/src/main/java/corecord/dev/domain/record/service/RecordService.java
+++ b/src/main/java/corecord/dev/domain/record/service/RecordService.java
@@ -2,6 +2,9 @@ package corecord.dev.domain.record.service;
 
 import corecord.dev.common.exception.GeneralException;
 import corecord.dev.common.status.ErrorStatus;
+import corecord.dev.domain.analysis.constant.Keyword;
+import corecord.dev.domain.analysis.exception.enums.AnalysisErrorStatus;
+import corecord.dev.domain.analysis.exception.model.AnalysisException;
 import corecord.dev.domain.analysis.service.AnalysisService;
 import corecord.dev.domain.folder.entity.Folder;
 import corecord.dev.domain.folder.exception.enums.FolderErrorStatus;
@@ -141,6 +144,21 @@ public class RecordService {
         return RecordConverter.toRecordListDto(folderName, recordList);
     }
 
+    /*
+     * keyword를 받아 해당 키워드를 가진 역량 분석 정보와 경험 기록 정보를 반환
+     * @param userId, keywordValue
+     * @return
+     */
+    @Transactional(readOnly = true)
+    public RecordResponse.KeywordRecordListDto getKeywordRecordList(Long userId, String keywordValue) {
+        User user = findUserById(userId);
+
+        // 해당 keyword를 가진 ability 객체 조회 후 맵핑된 Record 객체 리스트 조회
+        Keyword keyword = getKeyword(keywordValue);
+        List<Record> recordList = getRecordListByKeyword(user, keyword);
+
+        return RecordConverter.toKeywordRecordListDto(recordList);
+    }
 
     private void validHasUserTmpMemo(User user) {
         if (user.getTmpMemo() != null)
@@ -190,4 +208,14 @@ public class RecordService {
         return recordRepository.findRecords(user);
     }
 
+    private List<Record> getRecordListByKeyword(User user, Keyword keyword) {
+        return recordRepository.findRecordByKeyword(keyword, user);
+    }
+
+    private Keyword getKeyword(String keywordValue) {
+        Keyword keyword = Keyword.getName(keywordValue);
+        if (keyword == null)
+            throw new AnalysisException(AnalysisErrorStatus.INVALID_KEYWORD);
+        return keyword;
+    }
 }


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #31 

### 💡 작업내용
- 폴더별 경험 기록 리스트 조회 기능 구현
  - `default = "all"` 으로 설정해, `folder` parameter 값이 없으면 전체 기록 리스트 조회 
- 역량 키워드별 경험 기록 리스트 조회 기능 구현
- 최근 생성 순 정렬
- 임시 저장된 기록 제외 리스트 반환
- `fetch join`을 이용한 성능 최적화 적용
  - 쿼리 1번으로 리스트 조회 및 반환


### 📸 스크린샷(선택)
<img width="697" alt="스크린샷 2024-10-31 오후 8 10 14" src="https://github.com/user-attachments/assets/8868c770-d5d3-4e78-92fb-a1321283c97d">
<img width="664" alt="스크린샷 2024-10-31 오후 7 05 01" src="https://github.com/user-attachments/assets/bf452f17-44d0-4437-99c6-c7f2db5cbd6e">



### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
