### PR TITLE
[Feat/#43] 채팅 경험 요약하기 기능

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -32,6 +32,12 @@ jobs:
         echo "${{ secrets.CHAT_PROMPT }}" > ./src/main/resources/chat-prompt.txt
       shell: bash
 
+    - name: make chat-summary-prompt.txt
+      run: |
+        touch ./src/main/resources/chat-summary-prompt.txt
+        echo "${{ secrets.CHAT_SUMMARY_PROMPT }}" > ./src/main/resources/chat-summary-prompt.txt
+      shell: bash
+
     - name: 빌드
       run: |
           chmod +x gradlew

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ out/
 .DS_Store
 src/main/resources/application-secret.yml
 src/main/resources/chat-prompt.txt
+src/main/resources/chat-summary-prompt.txt

--- a/src/main/java/corecord/dev/domain/chat/constant/ChatSuccessStatus.java
+++ b/src/main/java/corecord/dev/domain/chat/constant/ChatSuccessStatus.java
@@ -12,7 +12,8 @@ public enum ChatSuccessStatus implements BaseSuccessStatus {
     CHAT_ROOM_CREATE_SUCCESS(HttpStatus.CREATED, "S301", "채팅방 생성이 성공적으로 완료되었습니다."),
     CHAT_CREATE_SUCCESS(HttpStatus.CREATED, "S302", "채팅 생성이 성공적으로 완료되었습니다."),
     GET_CHAT_SUCCESS(HttpStatus.OK, "S303", "채팅 조회가 성공적으로 완료되었습니다."),
-    CHAT_DELETE_SUCCESS(HttpStatus.OK, "S304", "채팅 삭제가 성공적으로 완료되었습니다.");
+    CHAT_DELETE_SUCCESS(HttpStatus.OK, "S304", "채팅 삭제가 성공적으로 완료되었습니다."),
+    GET_CHAT_SUMMARY_SUCCESS(HttpStatus.OK, "S305", "채팅 요약 생성이 성공적으로 완료되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/corecord/dev/domain/chat/controller/ChatController.java
+++ b/src/main/java/corecord/dev/domain/chat/controller/ChatController.java
@@ -54,4 +54,13 @@ public class ChatController {
         chatService.deleteChatRoom(userId, chatRoomId);
         return ApiResponse.success(ChatSuccessStatus.CHAT_DELETE_SUCCESS);
     }
+
+    @GetMapping("/{chatRoomId}/summary")
+    public ResponseEntity<ApiResponse<ChatResponse.ChatSummaryDto>> getChatSummary(
+            @UserId Long userId,
+            @PathVariable(name = "chatRoomId") Long chatRoomId
+    ) {
+        ChatResponse.ChatSummaryDto chatSummaryDto = chatService.getChatSummary(userId, chatRoomId);
+        return ApiResponse.success(ChatSuccessStatus.GET_CHAT_SUMMARY_SUCCESS, chatSummaryDto);
+    }
 }

--- a/src/main/java/corecord/dev/domain/chat/controller/ChatController.java
+++ b/src/main/java/corecord/dev/domain/chat/controller/ChatController.java
@@ -15,7 +15,7 @@ import static corecord.dev.domain.chat.constant.ChatSuccessStatus.CHAT_ROOM_CREA
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/chat")
+@RequestMapping("/api/records/chat")
 public class ChatController {
     private final ChatService chatService;
 

--- a/src/main/java/corecord/dev/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/corecord/dev/domain/chat/converter/ChatConverter.java
@@ -52,4 +52,11 @@ public class ChatConverter {
                 .chats(chatList.stream().map(ChatConverter::toChatDetailDto).toList())
                 .build();
     }
+
+    public static ChatResponse.ChatSummaryDto toChatSummaryDto(ChatRoom chatRoom, String content) {
+        return ChatResponse.ChatSummaryDto.builder()
+                .chatRoomId(chatRoom.getChatRoomId())
+                .content(content)
+                .build();
+    }
 }

--- a/src/main/java/corecord/dev/domain/chat/dto/request/ChatSummaryRequest.java
+++ b/src/main/java/corecord/dev/domain/chat/dto/request/ChatSummaryRequest.java
@@ -1,0 +1,41 @@
+package corecord.dev.domain.chat.dto.request;
+
+
+import corecord.dev.domain.chat.entity.Chat;
+import lombok.Getter;
+
+import java.util.Collections;
+import java.util.List;
+
+@Getter
+public class ChatSummaryRequest {
+    private final String text;
+    private final String start = "";
+    private final String restart = "";
+    private final boolean includeTokens = false;
+    private final double topP = 0.8;
+    private final int topK = 4;
+    private final int maxTokens = 500;
+    private final double temperature = 0.85;
+    private final double repeatPenalty = 5.0;
+    private final boolean includeAiFilters = true;
+    private final boolean includeProbs = false;
+    private final List<String> stopBefore = Collections.singletonList("<|endoftext|>");
+
+    public ChatSummaryRequest(String text) {
+        this.text = text;
+    }
+
+    public static ChatSummaryRequest createChatSummaryRequest(List<Chat> chatHistory) {
+
+        // 기존 채팅 내역을 하나의 문자열로 병합
+        StringBuilder chatContentBuilder = new StringBuilder();
+        for (Chat chat : chatHistory) {
+            String role = chat.getAuthor() == 0 ? "Ai" : "User";
+            chatContentBuilder.append(role).append(": ").append(chat.getContent()).append("\n");
+        }
+        String chatContent = chatContentBuilder.toString();
+
+        return new ChatSummaryRequest(chatContent);
+    }
+}

--- a/src/main/java/corecord/dev/domain/chat/dto/request/ClovaRequest.java
+++ b/src/main/java/corecord/dev/domain/chat/dto/request/ClovaRequest.java
@@ -10,35 +10,23 @@ import java.util.Map;
 
 @Getter
 public class ClovaRequest {
-    private static final double TOP_P = 0.8;
-    private static final int TOP_K = 0;
     private static final int CHAT_MAX_TOKENS = 256;
     private static final int SUMMARY_MAX_TOKENS = 500;
-    private static final double TEMPERATURE = 0.5;
-    private static final double REPEAT_PENALTY = 5.0;
-    private static final boolean INCLUDE_AI_FILTERS = true;
-    private static final int SEED = 0;
     private static final String CHAT_SYSTEM_CONTENT = ResourceLoader.getResourceContent("chat-prompt.txt");
     private static final String SUMMARY_SYSTEM_CONTENT = ResourceLoader.getResourceContent("chat-summary-prompt.txt");
 
     private List<Map<String, String>> messages;
-    private double topP;
-    private int topK;
-    private int maxTokens;
-    private double temperature;
-    private double repeatPenalty;
-    private boolean includeAiFilters;
-    private int seed;
+    private final double topP = 0.8;
+    private final int topK = 0;
+    private final int maxTokens;
+    private final double temperature = 0.5;
+    private final double repeatPenalty = 5.0;
+    private final boolean includeAiFilters = true;
+    private final int seed = 0;
 
     public ClovaRequest(List<Map<String, String>> messages, int max_tokens) {
         this.messages = messages;
-        this.topP = TOP_P;
-        this.topK = TOP_K;
         this.maxTokens = max_tokens;
-        this.temperature = TEMPERATURE;
-        this.repeatPenalty = REPEAT_PENALTY;
-        this.includeAiFilters = INCLUDE_AI_FILTERS;
-        this.seed = SEED;
     }
 
     public static ClovaRequest createChatRequest(List<Chat> chatHistory, String userContent) {

--- a/src/main/java/corecord/dev/domain/chat/dto/request/ClovaRequest.java
+++ b/src/main/java/corecord/dev/domain/chat/dto/request/ClovaRequest.java
@@ -3,7 +3,6 @@ package corecord.dev.domain.chat.dto.request;
 import corecord.dev.common.util.ResourceLoader;
 import corecord.dev.domain.chat.entity.Chat;
 import lombok.Getter;
-import lombok.Setter;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,12 +12,14 @@ import java.util.Map;
 public class ClovaRequest {
     private static final double TOP_P = 0.8;
     private static final int TOP_K = 0;
-    private static final int MAX_TOKENS = 256;
+    private static final int CHAT_MAX_TOKENS = 256;
+    private static final int SUMMARY_MAX_TOKENS = 500;
     private static final double TEMPERATURE = 0.5;
     private static final double REPEAT_PENALTY = 5.0;
     private static final boolean INCLUDE_AI_FILTERS = true;
     private static final int SEED = 0;
-    private static final String SYSTEM_CONTENT = ResourceLoader.getResourceContent("chat-prompt.txt");
+    private static final String CHAT_SYSTEM_CONTENT = ResourceLoader.getResourceContent("chat-prompt.txt");
+    private static final String SUMMARY_SYSTEM_CONTENT = ResourceLoader.getResourceContent("chat-summary-prompt.txt");
 
     private List<Map<String, String>> messages;
     private double topP;
@@ -29,24 +30,24 @@ public class ClovaRequest {
     private boolean includeAiFilters;
     private int seed;
 
-    public ClovaRequest(List<Map<String, String>> messages) {
+    public ClovaRequest(List<Map<String, String>> messages, int max_tokens) {
         this.messages = messages;
         this.topP = TOP_P;
         this.topK = TOP_K;
-        this.maxTokens = MAX_TOKENS;
+        this.maxTokens = max_tokens;
         this.temperature = TEMPERATURE;
         this.repeatPenalty = REPEAT_PENALTY;
         this.includeAiFilters = INCLUDE_AI_FILTERS;
         this.seed = SEED;
     }
 
-    public static ClovaRequest createRequest(List<Chat> chatHistory, String userContent) {
+    public static ClovaRequest createChatRequest(List<Chat> chatHistory, String userContent) {
         List<Map<String, String>> messages = new ArrayList<>();
 
         // 시스템 메시지 추가
         messages.add(Map.of(
                 "role", "system",
-                "content", SYSTEM_CONTENT
+                "content", CHAT_SYSTEM_CONTENT
         ));
 
         // 기존 채팅 내역 추가
@@ -58,6 +59,33 @@ public class ClovaRequest {
         // 사용자 입력 추가
         messages.add(Map.of("role", "user", "content", userContent));
 
-        return new ClovaRequest(messages);
+        return new ClovaRequest(messages, CHAT_MAX_TOKENS);
     }
+
+    public static ClovaRequest createChatSummaryRequest(List<Chat> chatHistory) {
+        List<Map<String, String>> messages = new ArrayList<>();
+
+        // 시스템 메시지 추가
+        messages.add(Map.of(
+                "role", "system",
+                "content", SUMMARY_SYSTEM_CONTENT
+        ));
+
+        // 기존 채팅 내역을 하나의 문자열로 병합
+        StringBuilder chatContentBuilder = new StringBuilder();
+        for (Chat chat : chatHistory) {
+            String role = chat.getAuthor() == 0 ? "ai" : "recorder";
+            chatContentBuilder.append(role).append(": ").append(chat.getContent()).append("\n");
+        }
+        String chatContent = chatContentBuilder.toString();
+
+        // 병합된 내용을 추가
+        messages.add(Map.of(
+                "role", "user",
+                "content", chatContent
+        ));
+
+        return new ClovaRequest(messages, SUMMARY_MAX_TOKENS);
+    }
+
 }

--- a/src/main/java/corecord/dev/domain/chat/dto/response/ChatResponse.java
+++ b/src/main/java/corecord/dev/domain/chat/dto/response/ChatResponse.java
@@ -46,5 +46,14 @@ public class ChatResponse {
         private String created_at;
     }
 
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @Data
+    public static class ChatSummaryDto {
+        private Long chatRoomId;
+        private String content;
+    }
+
 
 }

--- a/src/main/java/corecord/dev/domain/chat/exception/enums/ChatErrorStatus.java
+++ b/src/main/java/corecord/dev/domain/chat/exception/enums/ChatErrorStatus.java
@@ -11,7 +11,8 @@ public enum ChatErrorStatus implements BaseErrorStatus {
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "E0302_CHAT_ROOM_NOT_FOUND", "존재하지 않는 채팅방입니다."),
     CHAT_AI_RESPONSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E0302_CHAT_AI_RESPONSE_ERROR", "AI 응답 생성 중 오류가 발생했습니다."),
     CHAT_CLIENT_ERROR(HttpStatus.BAD_REQUEST, "E0302_CHAT_CLIENT_ERROR", "AI 클라이언트 요청 오류가 발생했습니다."),
-    CHAT_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E0302_CHAT_SERVER_ERROR", "AI 서버에 오류가 발생했습니다.");
+    CHAT_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E0302_CHAT_SERVER_ERROR", "AI 서버에 오류가 발생했습니다."),
+    CREATE_SUMMARY_ERROR(HttpStatus.BAD_REQUEST, "E0305_CREATE_SUMMARY_ERROR", "경험 기록의 내용이 충분하지 않습니다."),;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/corecord/dev/domain/chat/service/ClovaService.java
+++ b/src/main/java/corecord/dev/domain/chat/service/ClovaService.java
@@ -35,6 +35,7 @@ public class ClovaService {
 
     public String generateAiResponse(ClovaRequest clovaRequest) {
         try {
+            log.info("AI 요청: {}", clovaRequest.getMessages());
             String responseBody = webClient.post()
                     .uri(chatHost)
                     .header("X-NCP-CLOVASTUDIO-API-KEY", chatApiKey)

--- a/src/main/java/corecord/dev/domain/chat/service/SummaryService.java
+++ b/src/main/java/corecord/dev/domain/chat/service/SummaryService.java
@@ -1,0 +1,80 @@
+package corecord.dev.domain.chat.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import corecord.dev.domain.chat.dto.request.ChatSummaryRequest;
+import corecord.dev.domain.chat.exception.enums.ChatErrorStatus;
+import corecord.dev.domain.chat.exception.model.ChatException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientException;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class SummaryService {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final WebClient webClient = WebClient.create();
+
+    @Value("${ncp.chat-ai.host}")
+    private String chatAiHost;
+
+    @Value("${ncp.chat-ai.api-key}")
+    private String chatAiApiKey;
+
+    @Value("${ncp.chat-ai.api-key-primary-val}")
+    private String chatAiApiKeyPrimaryVal;
+
+    @Value("${ncp.chat-ai.request-id}")
+    private String chatAiRequestId;
+
+    public String generateAiResponse(ChatSummaryRequest chatSummaryRequest) {
+        try {
+            log.info("AI 요청: {}", chatSummaryRequest.getText());
+
+            String responseBody = webClient.post()
+                    .uri(chatAiHost)
+                    .header("X-NCP-CLOVASTUDIO-API-KEY", chatAiApiKey)
+                    .header("X-NCP-APIGW-API-KEY", chatAiApiKeyPrimaryVal)
+                    .header("X-NCP-CLOVASTUDIO-REQUEST-ID", chatAiRequestId)
+                    .header("Content-Type", "application/json; charset=utf-8")
+                    .header("Accept", "application/json")
+                    .bodyValue(chatSummaryRequest)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> {
+                        log.error("클라이언트 오류 발생: 상태 코드 - {}", clientResponse.statusCode());
+                        return clientResponse.bodyToMono(String.class)
+                                .map(errorBody -> new ChatException(ChatErrorStatus.CHAT_CLIENT_ERROR));
+                    })
+                    .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> {
+                        log.error("서버 오류 발생: 상태 코드 - {}", clientResponse.statusCode());
+                        return clientResponse.bodyToMono(String.class)
+                                .map(errorBody -> new ChatException(ChatErrorStatus.CHAT_SERVER_ERROR));
+                    })
+                    .bodyToMono(String.class)
+                    .block();
+
+            log.info("AI 응답: {}", responseBody);
+            return parseContentFromResponse(responseBody);
+        } catch (WebClientException e) {
+            log.error("채팅 AI 응답 생성 실패", e);
+            throw new ChatException(ChatErrorStatus.CHAT_AI_RESPONSE_ERROR);
+        }
+    }
+
+    private String parseContentFromResponse(String responseBody) {
+        try {
+            JsonNode root = objectMapper.readTree(responseBody);
+            JsonNode resultText = root.path("result").path("text");
+            return resultText.asText();
+        } catch (Exception e) {
+            log.error("응답 파싱 실패", e);
+            throw new ChatException(ChatErrorStatus.CHAT_AI_RESPONSE_ERROR);
+        }
+    }
+}


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #43 
- closed #48 

### 💡 작업내용
- chat 엔드포인트 통일
- 경험 요약하기 기능 구현
- Clova Studio 플레이그라운드 API 연결
- 튜님 AI API 연결

### 📸 스크린샷(선택)
<img width="535" alt="image" src="https://github.com/user-attachments/assets/c657f3d3-f0b5-418e-a45f-3ecccf0e64d7">


### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
- 플레이그라운드 AI와 튜닝 AI 두가지 사용해서 테스트를 돌려본 결과 각 장단점이 존재했습니다.
- 플레이그라운드 AI의 경우 프롬프팅으로 하기 때문에 규칙 설정같은 부분을 섬세하게 조정이 가능합니다. 그러나 잔실수가 존재했습니다.(음슴체 사용)
- 튜닝 AI의 경우 어투 등 정형화되게 입력, 출력은 잘하지만, 규칙 설정을 할 수가 없어서 오류 반환 및 500자 설정 처리 등이 불가하다는 단점이 있었습니다.
- 그래서 우선 두가지 버전 다 개발은 해두었고 4차 스프린트할때, 테스트와 프롬프팅 업데이트 더 해보면서 둘 중에 무엇을 사용할지 결정하려고 합니다. 현재는 플레이그라운드 AI에 연결해두었습니다.
- 튜닝 AI 관련 코드-> SummaryService, ChatSummaryRequest
- 플레이그라운드 AI 관련 코드 -> ClovaService, ClovaRequest

- 그리고 chat-summary-prompt.txt 와 application-secret.yml 업데이트 했습니다. (노션 참고)
