### PR TITLE
[Feat/#44] 채팅 경험 기록 임시 저장 기능 구현

### DIFF
--- a/src/main/java/corecord/dev/domain/chat/constant/ChatSuccessStatus.java
+++ b/src/main/java/corecord/dev/domain/chat/constant/ChatSuccessStatus.java
@@ -13,7 +13,8 @@ public enum ChatSuccessStatus implements BaseSuccessStatus {
     CHAT_CREATE_SUCCESS(HttpStatus.CREATED, "S302", "채팅 생성이 성공적으로 완료되었습니다."),
     GET_CHAT_SUCCESS(HttpStatus.OK, "S303", "채팅 조회가 성공적으로 완료되었습니다."),
     CHAT_DELETE_SUCCESS(HttpStatus.OK, "S304", "채팅 삭제가 성공적으로 완료되었습니다."),
-    GET_CHAT_SUMMARY_SUCCESS(HttpStatus.OK, "S305", "채팅 요약 생성이 성공적으로 완료되었습니다.");
+    GET_CHAT_SUMMARY_SUCCESS(HttpStatus.OK, "S305", "채팅 요약 생성이 성공적으로 완료되었습니다."),
+    GET_CHAT_TMP_SUCCESS(HttpStatus.OK, "S306", "임시 채팅 조회가 성공적으로 완료되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/corecord/dev/domain/chat/constant/ChatSuccessStatus.java
+++ b/src/main/java/corecord/dev/domain/chat/constant/ChatSuccessStatus.java
@@ -14,7 +14,8 @@ public enum ChatSuccessStatus implements BaseSuccessStatus {
     GET_CHAT_SUCCESS(HttpStatus.OK, "S303", "채팅 조회가 성공적으로 완료되었습니다."),
     CHAT_DELETE_SUCCESS(HttpStatus.OK, "S304", "채팅 삭제가 성공적으로 완료되었습니다."),
     GET_CHAT_SUMMARY_SUCCESS(HttpStatus.OK, "S305", "채팅 요약 생성이 성공적으로 완료되었습니다."),
-    GET_CHAT_TMP_SUCCESS(HttpStatus.OK, "S306", "임시 채팅 조회가 성공적으로 완료되었습니다.");
+    GET_CHAT_TMP_SUCCESS(HttpStatus.OK, "S306", "임시 채팅 조회가 성공적으로 완료되었습니다."),
+    CREATE_CHAT_TMP_SUCCESS(HttpStatus.CREATED, "S307", "채팅 임시 저장이 성공적으로 완료되었습니다."),;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/corecord/dev/domain/chat/controller/ChatController.java
+++ b/src/main/java/corecord/dev/domain/chat/controller/ChatController.java
@@ -63,4 +63,12 @@ public class ChatController {
         ChatResponse.ChatSummaryDto chatSummaryDto = chatService.getChatSummary(userId, chatRoomId);
         return ApiResponse.success(ChatSuccessStatus.GET_CHAT_SUMMARY_SUCCESS, chatSummaryDto);
     }
+
+    @GetMapping("/tmp")
+    public ResponseEntity<ApiResponse<ChatResponse.ChatTmpDto>> getChatTmp(
+            @UserId Long userId
+    ) {
+        ChatResponse.ChatTmpDto chatTmpDto = chatService.getChatTmp(userId);
+        return ApiResponse.success(ChatSuccessStatus.GET_CHAT_TMP_SUCCESS, chatTmpDto);
+    }
 }

--- a/src/main/java/corecord/dev/domain/chat/controller/ChatController.java
+++ b/src/main/java/corecord/dev/domain/chat/controller/ChatController.java
@@ -71,4 +71,13 @@ public class ChatController {
         ChatResponse.ChatTmpDto chatTmpDto = chatService.getChatTmp(userId);
         return ApiResponse.success(ChatSuccessStatus.GET_CHAT_TMP_SUCCESS, chatTmpDto);
     }
+
+    @PostMapping("/{chatRoomId}/tmp")
+    public ResponseEntity<ApiResponse<Void>> saveChatTmp(
+            @UserId Long userId,
+            @PathVariable(name = "chatRoomId") Long chatRoomId
+    ) {
+        chatService.saveChatTmp(userId, chatRoomId);
+        return ApiResponse.success(ChatSuccessStatus.CREATE_CHAT_TMP_SUCCESS);
+    }
 }

--- a/src/main/java/corecord/dev/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/corecord/dev/domain/chat/converter/ChatConverter.java
@@ -59,4 +59,18 @@ public class ChatConverter {
                 .content(content)
                 .build();
     }
+
+    public static ChatResponse.ChatTmpDto toExistingChatTmpDto(Long chatRoomId) {
+        return ChatResponse.ChatTmpDto.builder()
+                .isExist(true)
+                .chatRoomId(chatRoomId)
+                .build();
+    }
+
+    public static ChatResponse.ChatTmpDto toNotExistingChatTmpDto() {
+        return ChatResponse.ChatTmpDto.builder()
+                .isExist(false)
+                .chatRoomId(null)
+                .build();
+    }
 }

--- a/src/main/java/corecord/dev/domain/chat/dto/response/ChatResponse.java
+++ b/src/main/java/corecord/dev/domain/chat/dto/response/ChatResponse.java
@@ -55,5 +55,14 @@ public class ChatResponse {
         private String content;
     }
 
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @Data
+    public static class ChatTmpDto {
+        private Long chatRoomId;
+        private boolean isExist;
+    }
+
 
 }

--- a/src/main/java/corecord/dev/domain/chat/exception/enums/ChatErrorStatus.java
+++ b/src/main/java/corecord/dev/domain/chat/exception/enums/ChatErrorStatus.java
@@ -12,7 +12,8 @@ public enum ChatErrorStatus implements BaseErrorStatus {
     CHAT_AI_RESPONSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E0302_CHAT_AI_RESPONSE_ERROR", "AI 응답 생성 중 오류가 발생했습니다."),
     CHAT_CLIENT_ERROR(HttpStatus.BAD_REQUEST, "E0302_CHAT_CLIENT_ERROR", "AI 클라이언트 요청 오류가 발생했습니다."),
     CHAT_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E0302_CHAT_SERVER_ERROR", "AI 서버에 오류가 발생했습니다."),
-    CREATE_SUMMARY_ERROR(HttpStatus.BAD_REQUEST, "E0305_CREATE_SUMMARY_ERROR", "경험 기록의 내용이 충분하지 않습니다."),;
+    CREATE_SUMMARY_ERROR(HttpStatus.BAD_REQUEST, "E0305_CREATE_SUMMARY_ERROR", "경험 기록의 내용이 충분하지 않습니다."),
+    TMP_CHAT_EXIST(HttpStatus.BAD_REQUEST, "E0307_TMP_CHAT_EXIST", "임시 채팅이 이미 존재합니다."),;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/corecord/dev/domain/chat/service/ChatService.java
+++ b/src/main/java/corecord/dev/domain/chat/service/ChatService.java
@@ -123,6 +123,22 @@ public class ChatService {
         return ChatConverter.toChatSummaryDto(chatRoom, summary);
     }
 
+    /*
+     * user의 임시 채팅방과 유무를 반환
+     * @param userId
+     * @return chatTmpDto
+     */
+    @Transactional
+    public ChatResponse.ChatTmpDto getChatTmp(Long userId) {
+        User user = findUserById(userId);
+        if(user.getTmpChat() == null) {
+            return ChatConverter.toNotExistingChatTmpDto();
+        }
+        // 임시 채팅 제거 후 반환
+        user.deleteTmpChat();
+        return ChatConverter.toExistingChatTmpDto(user.getTmpChat());
+    }
+
     private static void validateChatList(boolean chatList) {
         if (chatList) {
             throw new ChatException(ChatErrorStatus.CREATE_SUMMARY_ERROR);

--- a/src/main/java/corecord/dev/domain/chat/service/ChatService.java
+++ b/src/main/java/corecord/dev/domain/chat/service/ChatService.java
@@ -135,8 +135,26 @@ public class ChatService {
             return ChatConverter.toNotExistingChatTmpDto();
         }
         // 임시 채팅 제거 후 반환
+        Long chatRoomId = user.getTmpChat();
         user.deleteTmpChat();
-        return ChatConverter.toExistingChatTmpDto(user.getTmpChat());
+        return ChatConverter.toExistingChatTmpDto(chatRoomId);
+    }
+
+    /*
+     * user의 채팅방을 임시 저장
+     * @param userId
+     * @param chatRoomId
+     */
+    @Transactional
+    public void saveChatTmp(Long userId, Long chatRoomId) {
+        User user = findUserById(userId);
+        ChatRoom chatRoom = findChatRoomById(chatRoomId, user);
+
+        // 이미 임시 저장된 채팅방이 있는 경우
+        if(user.getTmpChat() != null) {
+            throw new ChatException(ChatErrorStatus.TMP_CHAT_EXIST);
+        }
+        user.updateTmpChat(chatRoom.getChatRoomId());
     }
 
     private static void validateChatList(boolean chatList) {

--- a/src/main/java/corecord/dev/domain/user/entity/User.java
+++ b/src/main/java/corecord/dev/domain/user/entity/User.java
@@ -55,6 +55,10 @@ public class User extends BaseEntity {
         this.tmpMemo = tmpMemo;
     }
 
+    public void updateTmpChat(Long tmpChat) {
+        this.tmpChat = tmpChat;
+    }
+
     public void deleteTmpMemo(){
         this.tmpMemo = null;
     }


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #44 

### 💡 작업내용
- 채팅 임시 저장 조회 기능 구현 -> 조회 후 tmpChat 삭제
- 채팅 임시 저장하기 기능 구현

### 📸 스크린샷(선택)
<img width="376" alt="image" src="https://github.com/user-attachments/assets/e94905b2-8d7a-4d6f-aeca-3d7a7ef14e73">

<img width="316" alt="image" src="https://github.com/user-attachments/assets/f8621c6d-6ced-411b-a9f3-cb613b728faa">

### 📝 기타
- MEMO 와 차이점은 chat은 임시 채팅 조회 후에 [3.3] 채팅 조회 API와 [3.4] 채팅방 삭제 API를 프론트에서 요청해야하는 로직으로 했습니다.