### PR TITLE
[Feat/#50] 역량 키워드 그래프 기능 구현

### DIFF
--- a/src/main/java/corecord/dev/domain/analysis/constant/AnalysisSuccessStatus.java
+++ b/src/main/java/corecord/dev/domain/analysis/constant/AnalysisSuccessStatus.java
@@ -11,7 +11,9 @@ public enum AnalysisSuccessStatus implements BaseSuccessStatus {
     ANALYSIS_GET_SUCCESS(HttpStatus.CREATED, "S502", "역량별 경험 조회가 성공적으로 완료되었습니다."),
     ANALYSIS_UPDATE_SUCCESS(HttpStatus.OK, "S701", "역량별 경험 수정이 성공적으로 완료되었습니다."),
     ANALYSIS_DELETE_SUCCESS(HttpStatus.OK, "S702", "역량별 경험 삭제가 성공적으로 완료되었습니다."),
-    KEYWORD_LIST_GET_SUCCESS(HttpStatus.OK, "S505", "역량 키워드 리스트 조회가 성공적으로 완료되었습니다.");
+    KEYWORD_LIST_GET_SUCCESS(HttpStatus.OK, "S505", "역량 키워드 리스트 조회가 성공적으로 완료되었습니다."),
+    KEYWORD_GRAPH_GET_SUCCESS(HttpStatus.OK, "S202", "역량 키워드 그래프 조회가 성공적으로 완료되었습니다.")
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/corecord/dev/domain/analysis/controller/AnalysisController.java
+++ b/src/main/java/corecord/dev/domain/analysis/controller/AnalysisController.java
@@ -50,4 +50,12 @@ public class AnalysisController {
         AnalysisResponse.KeywordListDto analysisResponse = analysisService.getKeywordList(userId);
         return ApiResponse.success(AnalysisSuccessStatus.KEYWORD_LIST_GET_SUCCESS, analysisResponse);
     }
+
+    @GetMapping("/graph")
+    public ResponseEntity<ApiResponse<AnalysisResponse.GraphDto>> getKeywordGraph(
+            @UserId Long userId
+    ) {
+        AnalysisResponse.GraphDto analysisResponse = analysisService.getKeywordGraph(userId);
+        return ApiResponse.success(AnalysisSuccessStatus.KEYWORD_GRAPH_GET_SUCCESS, analysisResponse);
+    }
 }

--- a/src/main/java/corecord/dev/domain/analysis/converter/AnalysisConverter.java
+++ b/src/main/java/corecord/dev/domain/analysis/converter/AnalysisConverter.java
@@ -58,4 +58,10 @@ public class AnalysisConverter {
                 .keywordList(keywordList)
                 .build();
     }
+
+    public static AnalysisResponse.GraphDto toGraphDto(List<AnalysisResponse.KeywordStateDto> keywordStateDtoList) {
+        return AnalysisResponse.GraphDto.builder()
+                .keywordGraph(keywordStateDtoList)
+                .build();
+    }
 }

--- a/src/main/java/corecord/dev/domain/analysis/dto/response/AnalysisResponse.java
+++ b/src/main/java/corecord/dev/domain/analysis/dto/response/AnalysisResponse.java
@@ -1,5 +1,6 @@
 package corecord.dev.domain.analysis.dto.response;
 
+import corecord.dev.domain.analysis.constant.Keyword;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -38,5 +39,26 @@ public class AnalysisResponse {
     @Data
     public static class KeywordListDto {
         private List<String> keywordList;
+    }
+
+    @Data
+    public static class KeywordStateDto {
+        private String keyword;
+        private Long count;
+        private String percent;
+
+        public KeywordStateDto(Keyword keyword, Long count, Double percent) {
+            this.keyword = keyword.getValue();
+            this.count = count;
+            this.percent = Math.round(percent) + "%";
+        }
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @Data
+    public static class GraphDto {
+        List<KeywordStateDto> keywordGraph;
     }
 }

--- a/src/main/java/corecord/dev/domain/analysis/repository/AbilityRepository.java
+++ b/src/main/java/corecord/dev/domain/analysis/repository/AbilityRepository.java
@@ -1,9 +1,23 @@
 package corecord.dev.domain.analysis.repository;
 
+import corecord.dev.domain.analysis.dto.response.AnalysisResponse;
 import corecord.dev.domain.analysis.entity.Ability;
+import corecord.dev.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface AbilityRepository extends JpaRepository<Ability, Long> {
+        @Query("SELECT new corecord.dev.domain.analysis.dto.response.AnalysisResponse$KeywordStateDto(" +
+                "a.keyword, COUNT(a), " + // 각 키워드의 개수 집계
+                "(COUNT(a) * 1.0 / (SELECT COUNT(a2) FROM Ability a2 WHERE a2.user = :user)) * 100.0) " + // 각 키워드의 비율 집계
+                "FROM Ability a " +
+                "WHERE a.user = :user " +
+                "GROUP BY a.keyword " +
+                "ORDER BY 3 desc ") // 비율 높은 순 정렬
+        List<AnalysisResponse.KeywordStateDto> findKeywordStateDtoList(@Param(value = "user") User user);
 }

--- a/src/main/java/corecord/dev/domain/analysis/service/AnalysisService.java
+++ b/src/main/java/corecord/dev/domain/analysis/service/AnalysisService.java
@@ -125,6 +125,21 @@ public class AnalysisService {
         return AnalysisConverter.toKeywordListDto(keywordList);
     }
 
+    /*
+     * user의 각 역량 키워드에 대한 개수, 퍼센티지 정보를 반환
+     * @param userId
+     * @return
+     */
+    @Transactional(readOnly = true)
+    public AnalysisResponse.GraphDto getKeywordGraph(Long userId) {
+        User user = findUserById(userId);
+
+        // keyword graph 정보 조회
+        List<AnalysisResponse.KeywordStateDto> keywordGraph = findKeywordGraph(user);
+
+        return AnalysisConverter.toGraphDto(keywordGraph);
+    }
+
     private void validIsUserAuthorizedForAnalysis(User user, Analysis analysis) {
         if (!analysis.getRecord().getUser().equals(user))
             throw new RecordException(RecordErrorStatus.USER_RECORD_UNAUTHORIZED);
@@ -160,5 +175,9 @@ public class AnalysisService {
     private Analysis findAnalysisById(Long analysisId) {
         return analysisRepository.findAnalysisById(analysisId)
                 .orElseThrow(() -> new AnalysisException(AnalysisErrorStatus.ANALYSIS_NOT_FOUND));
+    }
+
+    private List<AnalysisResponse.KeywordStateDto> findKeywordGraph(User user) {
+        return abilityRepository.findKeywordStateDtoList(user);
     }
 }


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #50 

### 💡 작업내용
- 역량 키워드 그래프 조회 기능 구현
- user의 역량 키워드 각각의 개수와 비율(%) 정보를 반환
- 비율은 소수점 첫 번째 자리에서 반올림
- 비율 높은 순 정렬

### 📸 스크린샷(선택)
<img width="846" alt="스크린샷 2024-11-04 오후 9 38 40" src="https://github.com/user-attachments/assets/6009726a-8aff-44c3-9a7f-044ce68ea484">


### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
- repository에서 projection을 이용해 바로 정보를 dto로 받아와서 사용합니다!
