### PR TITLE
[Refactor/#56] 최근 생성된 경험 기록 리스트 조회 기능 재구현

### DIFF
--- a/src/main/java/corecord/dev/domain/record/constant/RecordSuccessStatus.java
+++ b/src/main/java/corecord/dev/domain/record/constant/RecordSuccessStatus.java
@@ -15,7 +15,8 @@ public enum RecordSuccessStatus implements BaseSuccessStatus {
     MEMO_RECORD_TMP_GET_SUCCESS(HttpStatus.OK, "S402", "메모 경험 기록 임시 저장 내역 조회가 성공적으로 완료되었습니다."),
     RECORD_LIST_GET_SUCCESS(HttpStatus.OK, "S602", "폴더별 경험 기록 리스트 조회가 성공적으로 완료되었습니다."),
     KEYWORD_RECORD_LIST_GET_SUCCESS(HttpStatus.OK, "S503", "역량 키워드별 경험 기록 리스트 조회가 성공적으로 완료되었습니다."),
-    RECORD_FOLDER_UPDATE_SUCCESS(HttpStatus.OK, "S504", "경험 기록의 폴더 변경이 성공적으로 완료되었습니다.")
+    RECORD_FOLDER_UPDATE_SUCCESS(HttpStatus.OK, "S504", "경험 기록의 폴더 변경이 성공적으로 완료되었습니다."),
+    RECENT_RECORD_LIST_GET_SUCCESS(HttpStatus.OK, "S201", "최근 생성된 경험 기록 리스트 조회가 성공적으로 완료되었습니다."),
             ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/corecord/dev/domain/record/controller/RecordController.java
+++ b/src/main/java/corecord/dev/domain/record/controller/RecordController.java
@@ -78,4 +78,12 @@ public class RecordController {
         return ApiResponse.success(RecordSuccessStatus.RECORD_FOLDER_UPDATE_SUCCESS);
     }
 
+    @GetMapping("/recent")
+    public ResponseEntity<ApiResponse<RecordResponse.RecordListDto>> getRecentRecordList(
+            @UserId Long userId
+    ) {
+        RecordResponse.RecordListDto recordResponse = recordService.getRecentRecordList(userId);
+        return ApiResponse.success(RecordSuccessStatus.RECENT_RECORD_LIST_GET_SUCCESS, recordResponse);
+    }
+
 }

--- a/src/main/java/corecord/dev/domain/record/repository/RecordRepository.java
+++ b/src/main/java/corecord/dev/domain/record/repository/RecordRepository.java
@@ -4,6 +4,7 @@ import corecord.dev.domain.analysis.constant.Keyword;
 import corecord.dev.domain.folder.entity.Folder;
 import corecord.dev.domain.record.entity.Record;
 import corecord.dev.domain.user.entity.User;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -48,6 +49,16 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
     List<Record> findRecordsByKeyword(
             @Param(value = "keyword")Keyword keyword,
             @Param(value = "user") User user);
+
+    @Query("SELECT r FROM Record r " +
+            "JOIN FETCH r.analysis a " +
+            "JOIN FETCH r.folder f " +
+            "JOIN FETCH a.abilityList al " +
+            "WHERE r.user = :user " +
+            "AND r.folder is not null ")  // 임시 저장 기록 제외
+    List<Record> findRecordsOrderByCreatedAt(
+            @Param(value = "user") User user,
+            Pageable pageable);
 
     @Query("SELECT r FROM Record r " +
             "JOIN FETCH r.analysis a " +

--- a/src/main/java/corecord/dev/domain/record/service/RecordService.java
+++ b/src/main/java/corecord/dev/domain/record/service/RecordService.java
@@ -21,6 +21,9 @@ import corecord.dev.domain.user.entity.User;
 import corecord.dev.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -172,6 +175,21 @@ public class RecordService {
         record.updateFolder(folder);
     }
 
+    /*
+     * 최근 생성된 경험 기록 리스트 3개를 반환
+     * @param userId
+     * @return
+     */
+    public RecordResponse.RecordListDto getRecentRecordList(Long userId) {
+        User user = findUserById(userId);
+
+        // 최근 생성된 3개의 데이터만 조회
+        Pageable pageable = PageRequest.of(0, 3, Sort.by("createdAt").descending());
+        List<Record> recordList = getRecordListOrderByCreatedAt(user, pageable);
+
+        return RecordConverter.toRecordListDto("all", recordList);
+    }
+
     private void validHasUserTmpMemo(User user) {
         if (user.getTmpMemo() != null)
             throw new RecordException(RecordErrorStatus.ALREADY_TMP_MEMO);
@@ -218,6 +236,10 @@ public class RecordService {
 
     private List<Record> getRecordList(User user) {
         return recordRepository.findRecords(user);
+    }
+
+    private List<Record> getRecordListOrderByCreatedAt(User user, Pageable pageable) {
+        return recordRepository.findRecordsOrderByCreatedAt(user, pageable);
     }
 
     private List<Record> getRecordListByKeyword(User user, Keyword keyword) {


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #56 

### 💡 작업내용
- 최근 생성된 경험 기록 리스트 조회 API 재구현
- JPQL에서 LIMIT절을 사용하지 못하기 때문에 `Pageable` 도입
  - createdAt desc 정렬
  - limit 3
- 폴더별 경험 조회 API와 동일한 응답 형태 사용  

### 📸 스크린샷(선택)
<img width="626" alt="스크린샷 2024-11-06 오전 10 10 41" src="https://github.com/user-attachments/assets/2af92f06-7509-4bf7-b0db-09b21616a060">


### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
