### PR TITLE
[Fix/#49] 채팅 + 메모 경험 기록하기 기능 구현

### DIFF
--- a/src/main/java/corecord/dev/domain/record/constant/RecordSuccessStatus.java
+++ b/src/main/java/corecord/dev/domain/record/constant/RecordSuccessStatus.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum RecordSuccessStatus implements BaseSuccessStatus {
 
-    MEMO_RECORD_CREATE_SUCCESS(HttpStatus.CREATED, "S404", "메모 경험 기록이 성공적으로 완료되었습니다."),
+    MEMO_RECORD_CREATE_SUCCESS(HttpStatus.CREATED, "S404", "경험 기록이 성공적으로 완료되었습니다."),
     MEMO_RECORD_DETAIL_GET_SUCCESS(HttpStatus.OK, "S401", "메모 경험 기록 세부 조회가 성공적으로 완료되었습니다."),
     MEMO_RECORD_TMP_CREATE_SUCCESS(HttpStatus.OK, "S403", "메모 경험 기록 임시 저장이 성공적으로 완료되었습니다."),
     MEMO_RECORD_TMP_GET_SUCCESS(HttpStatus.OK, "S402", "메모 경험 기록 임시 저장 내역 조회가 성공적으로 완료되었습니다."),

--- a/src/main/java/corecord/dev/domain/record/controller/RecordController.java
+++ b/src/main/java/corecord/dev/domain/record/controller/RecordController.java
@@ -16,12 +16,12 @@ import org.springframework.web.bind.annotation.*;
 public class RecordController {
     private final RecordService recordService;
 
-    @PostMapping("/memo")
+    @PostMapping("")
     public ResponseEntity<ApiResponse<RecordResponse.MemoRecordDto>> createMemoRecord(
             @UserId Long userId,
-            @RequestBody RecordRequest.MemoRecordDto memoRecordDto
+            @RequestBody RecordRequest.RecordDto recordDto
     ) {
-        RecordResponse.MemoRecordDto recordResponse = recordService.createMemoRecord(userId, memoRecordDto);
+        RecordResponse.MemoRecordDto recordResponse = recordService.createMemoRecord(userId, recordDto);
         return ApiResponse.success(RecordSuccessStatus.MEMO_RECORD_CREATE_SUCCESS, recordResponse);
     }
 

--- a/src/main/java/corecord/dev/domain/record/converter/RecordConverter.java
+++ b/src/main/java/corecord/dev/domain/record/converter/RecordConverter.java
@@ -2,6 +2,7 @@ package corecord.dev.domain.record.converter;
 
 import corecord.dev.domain.analysis.constant.Keyword;
 import corecord.dev.domain.analysis.entity.Ability;
+import corecord.dev.domain.chat.entity.ChatRoom;
 import corecord.dev.domain.folder.entity.Folder;
 import corecord.dev.domain.record.constant.RecordType;
 import corecord.dev.domain.record.dto.response.RecordResponse;
@@ -18,6 +19,19 @@ public class RecordConverter {
                 .user(user)
                 .content(content)
                 .folder(folder)
+                .type(RecordType.MEMO)
+                .build();
+    }
+
+    public static Record toChatRecordEntity(String title, String content, User user, Folder folder, ChatRoom chatRoom) {
+        return Record.builder()
+                .type(RecordType.CHAT)
+                .title(title)
+                .user(user)
+                .content(content)
+                .folder(folder)
+                .chatRoom(chatRoom)
+                .type(RecordType.CHAT)
                 .build();
     }
 

--- a/src/main/java/corecord/dev/domain/record/dto/request/RecordRequest.java
+++ b/src/main/java/corecord/dev/domain/record/dto/request/RecordRequest.java
@@ -1,17 +1,21 @@
 package corecord.dev.domain.record.dto.request;
 
+import corecord.dev.domain.record.constant.RecordType;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
 public class RecordRequest {
     @Data
-    public static class MemoRecordDto {
+    public static class RecordDto {
         @NotBlank(message = "제목을 입력해주세요.")
         private String title;
         @NotBlank(message = "내용을 입력해주세요.")
         private String content;
         @NotBlank(message = "저장할 폴더의 id를 입력해주세요.")
         private Long folderId;
+        @NotBlank(message = "저장할 기록의 타입을 입력해주세요.")
+        private RecordType recordType;
+        private Long chatRoomId;
     }
 
     @Data

--- a/src/main/java/corecord/dev/domain/record/service/RecordService.java
+++ b/src/main/java/corecord/dev/domain/record/service/RecordService.java
@@ -63,7 +63,7 @@ public class RecordService {
         recordRepository.save(record);
 
         // 역량 분석 레포트 생성
-//        analysisService.createAnalysis(record, user);
+        analysisService.createAnalysis(record, user);
 
         return RecordConverter.toMemoRecordDto(record);
     }


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #49 

### 💡 작업내용
- [4.4] 경험 기록하기 API 명세서 내용 수정 완료
- chatRoomId, recordType 요청에 추가
- 타입별로 저장 기능 구현

### 📸 스크린샷(선택)
<img width="625" alt="스크린샷 2024-11-06 오후 4 22 12" src="https://github.com/user-attachments/assets/c4dfbf97-8bdc-48b6-b091-e95165061e78">


### 📝 기타
- analysisService 부분 아직 구현 중인 것 같아서 우선 주석처리하고 경험 기록이 되는지만 테스트를 돌렸습니다. 추후 역량 분석하기 구현이 완료되면 다시 한 번 경험 기록 기능 테스트 필요합니다.
- [4.4] API 명세서 수정했으니 확인 부탁드립니다.
