### PR TITLE
[Feat/#45] MEMO ver. 경험 기록 요약 기능 구현

### DIFF
--- a/src/main/java/corecord/dev/common/util/ClovaRequest.java
+++ b/src/main/java/corecord/dev/common/util/ClovaRequest.java
@@ -93,4 +93,20 @@ public class ClovaRequest {
         return new ClovaRequest(messages, ABILITY_ANALYSIS_MAX_TOKENS);
     }
 
+    public static ClovaRequest createMemoSummaryRequest(String content) {
+        List<Map<String, String>> messages = new ArrayList<>();
+
+        // 시스템 메세지 추가
+        messages.add(Map.of(
+                "role", "system",
+                "content", SUMMARY_SYSTEM_CONTENT
+        ));
+
+        messages.add(Map.of(
+                "role", "user",
+                "content", content
+        ));
+        return new ClovaRequest(messages, SUMMARY_MAX_TOKENS);
+    }
+
 }

--- a/src/main/java/corecord/dev/domain/record/entity/Record.java
+++ b/src/main/java/corecord/dev/domain/record/entity/Record.java
@@ -56,4 +56,8 @@ public class Record extends BaseEntity {
             this.title = title;
         }
     }
+
+    public boolean isMemoType() {
+        return this.type == RecordType.MEMO;
+    }
 }


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #45

### 💡 작업내용
- MEMO ver. 경험 기록 요약 기능 구현
  - 역량 분석 API 호출 이전, MEMO type으로 작성된 경험 기록을 CLOVA STUDIO를 이용해 500자 이내로 요약합니다.
- 기존 summary-prompt.txt 사용  
- 요약한 Content를 Analysis의 Content로 저장

### 📸 스크린샷(선택)
<img width="817" alt="스크린샷 2024-11-07 오후 1 47 03" src="https://github.com/user-attachments/assets/98efc1a6-17dd-4069-adf4-ffca7f90114c">

<img width="1035" alt="스크린샷 2024-11-07 오후 1 48 50" src="https://github.com/user-attachments/assets/7ae2387b-ec80-4034-b27e-5604a5645071">


### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
- API 호출 비동기 처리 예정
- 경험 기록 요약 재요청 기능 구현 예정
