### PR TITLE
[Feat/#62] 역량 분석 재요청 기능 구현

### DIFF
--- a/src/main/java/corecord/dev/domain/analysis/constant/AnalysisSuccessStatus.java
+++ b/src/main/java/corecord/dev/domain/analysis/constant/AnalysisSuccessStatus.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum AnalysisSuccessStatus implements BaseSuccessStatus {
-    ANALYSIS_GET_SUCCESS(HttpStatus.CREATED, "S502", "역량별 경험 조회가 성공적으로 완료되었습니다."),
+    ANALYSIS_POST_SUCCESS(HttpStatus.CREATED, "S501", "역량별 경험 분석이 성공적으로 완료되었습니다."),
+    ANALYSIS_GET_SUCCESS(HttpStatus.OK, "S502", "역량별 경험 조회가 성공적으로 완료되었습니다."),
     ANALYSIS_UPDATE_SUCCESS(HttpStatus.OK, "S701", "역량별 경험 수정이 성공적으로 완료되었습니다."),
     ANALYSIS_DELETE_SUCCESS(HttpStatus.OK, "S702", "역량별 경험 삭제가 성공적으로 완료되었습니다."),
     KEYWORD_LIST_GET_SUCCESS(HttpStatus.OK, "S505", "역량 키워드 리스트 조회가 성공적으로 완료되었습니다."),

--- a/src/main/java/corecord/dev/domain/analysis/controller/AnalysisController.java
+++ b/src/main/java/corecord/dev/domain/analysis/controller/AnalysisController.java
@@ -16,6 +16,15 @@ import org.springframework.web.bind.annotation.*;
 public class AnalysisController {
     private final AnalysisService analysisService;
 
+    @PostMapping("/{recordId}")
+    public ResponseEntity<ApiResponse<AnalysisResponse.AnalysisDto>> postAnalysis(
+            @UserId Long userId,
+            @PathVariable(name = "recordId") Long recordId
+    ) {
+        AnalysisResponse.AnalysisDto analysisResponse = analysisService.postAnalysis(userId, recordId);
+        return ApiResponse.success(AnalysisSuccessStatus.ANALYSIS_POST_SUCCESS, analysisResponse);
+    }
+
     @GetMapping("/{analysisId}")
     public ResponseEntity<ApiResponse<AnalysisResponse.AnalysisDto>> getAnalysis(
             @UserId Long userId,

--- a/src/main/java/corecord/dev/domain/analysis/entity/Analysis.java
+++ b/src/main/java/corecord/dev/domain/analysis/entity/Analysis.java
@@ -30,7 +30,7 @@ public class Analysis extends BaseEntity {
     private String comment;
 
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
-    @JoinColumn(name = "record_id", nullable = false)
+    @JoinColumn(name = "record_id", nullable = true)
     private Record record;
 
     @BatchSize(size = 3)
@@ -41,4 +41,17 @@ public class Analysis extends BaseEntity {
         if (content != null && !content.isEmpty())
             this.content = content;
     }
+
+    public void updateComment(String comment) {
+        if (!comment.isEmpty()) {
+            this.comment = comment;
+        }
+    }
+
+    public void addAbility(Ability ability) {
+        if (ability != null) {
+            this.abilityList.add(ability);
+        }
+    }
+
 }

--- a/src/main/java/corecord/dev/domain/analysis/exception/enums/AnalysisErrorStatus.java
+++ b/src/main/java/corecord/dev/domain/analysis/exception/enums/AnalysisErrorStatus.java
@@ -9,9 +9,12 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum AnalysisErrorStatus implements BaseErrorStatus {
     INVALID_KEYWORD(HttpStatus.BAD_REQUEST, "E400_INVALID_KEYWORD", "역량 분석에 존재하지 않는 키워드입니다."),
+    OVERFLOW_ANALYSIS_CONTENT(HttpStatus.BAD_REQUEST, "E0400_OVERFLOW_CONTENT", "경험 기록 내용은 500자 이내여야 합니다."),
+    OVERFLOW_ANALYSIS_COMMENT(HttpStatus.BAD_REQUEST, "E0400_OVERFLOW_COMMENT", "경험 기록 코멘트는 200자 이내여야 합니다."),
+    OVERFLOW_ANALYSIS_KEYWORD_CONTENT(HttpStatus.BAD_REQUEST, "E0400_OVERFLOW_KEYWORD_CONTENT", "경험 기록 키워드별 내용은 200자 이내여야 합니다."),
     USER_ANALYSIS_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "E401_ANALYSIS_UNAUTHORIZED", "유저가 역량 분석에 대한 권한이 없습니다."),
     ANALYSIS_NOT_FOUND(HttpStatus.NOT_FOUND, "E0404_ANALYSIS", "존재하지 않는 역량 분석입니다."),
-    INVALID_ABILITY_ANALYSIS(HttpStatus.BAD_REQUEST, "E400_INVALID_ANALYSIS", "역량 분석 데이터 파싱 중 오류가 발생했습니다.")
+    INVALID_ABILITY_ANALYSIS(HttpStatus.BAD_REQUEST, "E400_INVALID_ANALYSIS", "역량 분석 데이터 파싱 중 오류가 발생했습니다."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #62 

### 💡 작업내용
- 역량 분석 재요청 기능 구현
- Record에 생성된 `Analysis` 객체가 없을 시, 기존 `createAnalysis()` 함수 호출
  - CLOVA STUDIO API 호출
  - `Analysis` 객체 생성 및 저장 
  - `Ability` 객체 생성 및 저장 
- Record에 생성된 `Analysis` 객체가 존재한다면, `recreateAnalysis()` 함수 호출
  - CLOVA STUDIO API 호출
  - `Analysis` 객체 정보 Update
  - 기존 `Ability` 객체 제거
  - 새로운 `Ability` 객체 생성 및 저장  
- 글자수 Validation 추가
- 중복 코드 최소화

### 📸 스크린샷(선택)
<img width="1048" alt="스크린샷 2024-11-07 오후 4 04 33" src="https://github.com/user-attachments/assets/84f776fc-9e10-4275-a8bd-e2b823bc1c32">


### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
