### PR TITLE
[Feat/#47] 경험 기록 리스트 조회 페이징 처리 구현

### DIFF
--- a/src/main/java/corecord/dev/domain/analysis/service/AnalysisService.java
+++ b/src/main/java/corecord/dev/domain/analysis/service/AnalysisService.java
@@ -217,7 +217,8 @@ public class AnalysisService {
 
             Ability ability = AnalysisConverter.toAbility(keyword, entry.getValue(), analysis, user);
             abilityRepository.save(ability);
-            analysis.addAbility(ability);
+            if (analysis.getAbilityList() != null)
+                analysis.addAbility(ability);
             abilityCount++;
         }
 

--- a/src/main/java/corecord/dev/domain/record/controller/RecordController.java
+++ b/src/main/java/corecord/dev/domain/record/controller/RecordController.java
@@ -55,7 +55,7 @@ public class RecordController {
     public ResponseEntity<ApiResponse<RecordResponse.RecordListDto>> getRecordListByFolder(
         @UserId Long userId,
         @RequestParam(name = "folder", defaultValue = "all") String folder,
-        @RequestParam(name = "lastRecordId") Long lastRecordId
+        @RequestParam(name = "lastRecordId", defaultValue = "0") Long lastRecordId
     ) {
         RecordResponse.RecordListDto recordResponse = recordService.getRecordList(userId, folder, lastRecordId);
         return ApiResponse.success(RecordSuccessStatus.RECORD_LIST_GET_SUCCESS, recordResponse);
@@ -65,7 +65,7 @@ public class RecordController {
     public ResponseEntity<ApiResponse<RecordResponse.KeywordRecordListDto>> getRecordListByKeyword(
             @UserId Long userId,
             @RequestParam(name = "keyword") String keyword,
-            @RequestParam(name = "lastRecordId") Long lastRecordId
+            @RequestParam(name = "lastRecordId", defaultValue = "0") Long lastRecordId
     ) {
         RecordResponse.KeywordRecordListDto recordResponse = recordService.getKeywordRecordList(userId, keyword, lastRecordId);
         return ApiResponse.success(RecordSuccessStatus.KEYWORD_RECORD_LIST_GET_SUCCESS, recordResponse);

--- a/src/main/java/corecord/dev/domain/record/controller/RecordController.java
+++ b/src/main/java/corecord/dev/domain/record/controller/RecordController.java
@@ -54,18 +54,20 @@ public class RecordController {
     @GetMapping("")
     public ResponseEntity<ApiResponse<RecordResponse.RecordListDto>> getRecordListByFolder(
         @UserId Long userId,
-        @RequestParam(name = "folder", defaultValue = "all") String folder
+        @RequestParam(name = "folder", defaultValue = "all") String folder,
+        @RequestParam(name = "lastRecordId") Long lastRecordId
     ) {
-        RecordResponse.RecordListDto recordResponse = recordService.getRecordList(userId, folder);
+        RecordResponse.RecordListDto recordResponse = recordService.getRecordList(userId, folder, lastRecordId);
         return ApiResponse.success(RecordSuccessStatus.RECORD_LIST_GET_SUCCESS, recordResponse);
     }
 
     @GetMapping("/keyword")
     public ResponseEntity<ApiResponse<RecordResponse.KeywordRecordListDto>> getRecordListByKeyword(
             @UserId Long userId,
-            @RequestParam(name = "keyword") String keyword
+            @RequestParam(name = "keyword") String keyword,
+            @RequestParam(name = "lastRecordId") Long lastRecordId
     ) {
-        RecordResponse.KeywordRecordListDto recordResponse = recordService.getKeywordRecordList(userId, keyword);
+        RecordResponse.KeywordRecordListDto recordResponse = recordService.getKeywordRecordList(userId, keyword, lastRecordId);
         return ApiResponse.success(RecordSuccessStatus.KEYWORD_RECORD_LIST_GET_SUCCESS, recordResponse);
     }
 

--- a/src/main/java/corecord/dev/domain/record/converter/RecordConverter.java
+++ b/src/main/java/corecord/dev/domain/record/converter/RecordConverter.java
@@ -76,7 +76,7 @@ public class RecordConverter {
                 .build();
     }
 
-    public static RecordResponse.RecordListDto toRecordListDto(String folder, List<Record> recordList) {
+    public static RecordResponse.RecordListDto toRecordListDto(String folder, List<Record> recordList, boolean hasNext) {
         List<RecordResponse.RecordDto> recordDtoList = recordList.stream()
                 .map(RecordConverter::toRecordDto)
                 .toList();
@@ -84,6 +84,7 @@ public class RecordConverter {
         return RecordResponse.RecordListDto.builder()
                 .folder(folder)
                 .recordDtoList(recordDtoList)
+                .hasNext(hasNext)
                 .build();
     }
 
@@ -100,13 +101,14 @@ public class RecordConverter {
                 .build();
     }
 
-    public static RecordResponse.KeywordRecordListDto toKeywordRecordListDto(List<Record> recordList) {
+    public static RecordResponse.KeywordRecordListDto toKeywordRecordListDto(List<Record> recordList, boolean hasNext) {
         List<RecordResponse.KeywordRecordDto> keywordRecordDtoList = recordList.stream()
                 .map(RecordConverter::toKeywordRecordDto)
                 .toList();
 
         return RecordResponse.KeywordRecordListDto.builder()
                 .recordDtoList(keywordRecordDtoList)
+                .hasNext(hasNext)
                 .build();
     }
 }

--- a/src/main/java/corecord/dev/domain/record/converter/RecordConverter.java
+++ b/src/main/java/corecord/dev/domain/record/converter/RecordConverter.java
@@ -69,6 +69,7 @@ public class RecordConverter {
 
         return RecordResponse.RecordDto.builder()
                 .analysisId(record.getAnalysis().getAnalysisId())
+                .recordId(record.getRecordId())
                 .folder(record.getFolder().getTitle())
                 .title(record.getTitle())
                 .keywordList(keywordList)
@@ -94,6 +95,7 @@ public class RecordConverter {
 
         return RecordResponse.KeywordRecordDto.builder()
                 .analysisId(record.getAnalysis().getAnalysisId())
+                .recordId(record.getRecordId())
                 .folder(record.getFolder().getTitle())
                 .title(record.getTitle())
                 .content(truncatedContent)

--- a/src/main/java/corecord/dev/domain/record/dto/response/RecordResponse.java
+++ b/src/main/java/corecord/dev/domain/record/dto/response/RecordResponse.java
@@ -36,6 +36,7 @@ public class RecordResponse {
     @Data
     public static class RecordDto {
         private Long analysisId;
+        private Long recordId;
         private String folder;
         private String title;
         private List<String> keywordList;
@@ -58,6 +59,7 @@ public class RecordResponse {
     @Data
     public static class KeywordRecordDto {
         private Long analysisId;
+        private Long recordId;
         private String folder;
         private String title;
         private String content;

--- a/src/main/java/corecord/dev/domain/record/dto/response/RecordResponse.java
+++ b/src/main/java/corecord/dev/domain/record/dto/response/RecordResponse.java
@@ -49,6 +49,7 @@ public class RecordResponse {
     public static class RecordListDto {
         private String folder;
         private List<RecordDto> recordDtoList;
+        private boolean hasNext;
     }
 
     @Builder
@@ -69,5 +70,6 @@ public class RecordResponse {
     @Data
     public static class KeywordRecordListDto {
         private List<KeywordRecordDto> recordDtoList;
+        private boolean hasNext;
     }
 }

--- a/src/main/java/corecord/dev/domain/record/repository/RecordRepository.java
+++ b/src/main/java/corecord/dev/domain/record/repository/RecordRepository.java
@@ -22,20 +22,26 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
             "JOIN FETCH r.folder f " +
             "JOIN FETCH a.abilityList al " +
             "WHERE r.user = :user " +
+            "AND r.recordId < :last_record_id " +
             "AND r.folder is not null AND r.folder = :folder "+ // 임시 저장 기록 제외
             "ORDER BY r.createdAt desc ") // 최근 생성 순 정렬
     List<Record> findRecordsByFolder(
             @Param(value = "folder") Folder folder,
-            @Param(value = "user") User user);
+            @Param(value = "user") User user,
+            @Param(value = "last_record_id") Long lastRecordId,
+            Pageable pageable);
 
     @Query("SELECT r FROM Record r " +
             "JOIN FETCH r.analysis a " +
             "JOIN FETCH r.folder f " +
             "JOIN FETCH a.abilityList al " +
             "WHERE r.user = :user " +
-            "AND r.folder is not null " + // 임시 저장 기록 제외
-            "ORDER BY r.createdAt DESC") // 최근 생성 순 정렬
-    List<Record> findRecords(@Param(value = "user") User user);
+            "AND r.recordId < :last_record_id " +
+            "AND r.folder is not null") // 임시 저장 기록 제외
+    List<Record> findRecords(
+            @Param(value = "user") User user,
+            @Param(value = "last_record_id") Long lastRecordId,
+            Pageable pageable);
 
 
     @Query("SELECT r FROM Ability a " +
@@ -44,11 +50,15 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
             "JOIN FETCH r.folder f " +
             "WHERE a.user = :user " +
             "AND a.keyword = :keyword " +
+            "AND r.recordId < :last_record_id " +
             "AND r.folder is not null " + // 임시 저장 기록 제외
             "ORDER BY r.createdAt DESC") // 최근 생성 순 정렬
     List<Record> findRecordsByKeyword(
             @Param(value = "keyword")Keyword keyword,
-            @Param(value = "user") User user);
+            @Param(value = "user") User user,
+            @Param(value = "last_record_id") Long lastRecordId,
+            Pageable pageable
+            );
 
     @Query("SELECT r FROM Record r " +
             "JOIN FETCH r.analysis a " +

--- a/src/main/java/corecord/dev/domain/record/repository/RecordRepository.java
+++ b/src/main/java/corecord/dev/domain/record/repository/RecordRepository.java
@@ -22,7 +22,7 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
             "JOIN FETCH r.folder f " +
             "JOIN FETCH a.abilityList al " +
             "WHERE r.user = :user " +
-            "AND r.recordId < :last_record_id " +
+            "AND (:last_record_id = 0 OR r.recordId < :last_record_id) " +  // 제일 마지막에 읽은 데이터 이후부터 가져옴
             "AND r.folder is not null AND r.folder = :folder "+ // 임시 저장 기록 제외
             "ORDER BY r.createdAt desc ") // 최근 생성 순 정렬
     List<Record> findRecordsByFolder(
@@ -36,7 +36,7 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
             "JOIN FETCH r.folder f " +
             "JOIN FETCH a.abilityList al " +
             "WHERE r.user = :user " +
-            "AND r.recordId < :last_record_id " +
+            "AND (:last_record_id = 0 OR r.recordId < :last_record_id) " + // 제일 마지막에 읽은 데이터 이후부터 가져옴
             "AND r.folder is not null") // 임시 저장 기록 제외
     List<Record> findRecords(
             @Param(value = "user") User user,
@@ -50,9 +50,8 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
             "JOIN FETCH r.folder f " +
             "WHERE a.user = :user " +
             "AND a.keyword = :keyword " +
-            "AND r.recordId < :last_record_id " +
-            "AND r.folder is not null " + // 임시 저장 기록 제외
-            "ORDER BY r.createdAt DESC") // 최근 생성 순 정렬
+            "AND (:last_record_id = 0 OR r.recordId < :last_record_id) " + // 제일 마지막에 읽은 데이터 이후부터 가져옴
+            "AND r.folder is not null") // 임시 저장 기록 제외
     List<Record> findRecordsByKeyword(
             @Param(value = "keyword")Keyword keyword,
             @Param(value = "user") User user,


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #47 

### 💡 작업내용
- 경험 기록 리스트 조회 스크롤 페이징 처리 구현
  - 키워드별 경험 기록 조회
  - 폴더별 경험 기록 조회
- 리스트 조회 response 수정
  - `boolean hasNext` field 추가  
- `long lastRecordId` request Pram 추가 
  - 마지막으로 조회한 recordId를 받아, 그 이후 조회할 데이터만을 repository에서 Where절을 이용해 필터링
  - `default value 0`으로 설정 
    - 첫 조회라면, 즉 lastRecordId가 0이라면 where절 필터링을 거치지 않도록 조정 
- repository에서 `size + 1` 만큼 데이터를 조회
  - 가져온 데이터의 크기 == size + 1 이라면, 프론트에게 제공할 size만큼의 데이터 이후 추가로 조회할 데이터가 남아있음을 의미
    - => `hasNext = true`
    - 마지막 데이터 제외 후 size만큼만 반환
- recordDto : `long recordId` field 추가
- keywordRecordDto : `long recordId` field 추가


### 📸 스크린샷(선택)
<img width="670" alt="스크린샷 2024-11-08 오전 5 00 05" src="https://github.com/user-attachments/assets/a30e5799-795f-47d8-b0f8-6f7eaeda6b73">
<img width="733" alt="스크린샷 2024-11-08 오전 5 03 08" src="https://github.com/user-attachments/assets/80e41325-4cc7-4df2-bec0-541f6bb8e2fc">


### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
- 참고자료 : 
  - https://dy-coding.tistory.com/entry/Offset을-사용하지-않는-무한-페이징-기능-구현
  - https://khdscor.tistory.com/101
- Querydsl 사용해도 좋을 듯 합니다
- 모든 리스트 조회는 20개씩 조회하도록 설정했습니다 
- count 쿼리가 나가지 않아 해당 방식을 채택했습니다  !
- itemCount 필드를 추가해야 할지 고민입니다