### PR TITLE
[Feat/#74] 채팅 경험 요약에 제목 자동 생성 기능 추가

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -34,8 +34,9 @@ jobs:
 
     - name: make chat-summary-prompt.txt
       run: |
-        touch ./src/main/resources/chat-summary-prompt.txt
-        echo "${{ secrets.CHAT_SUMMARY_PROMPT }}" > ./src/main/resources/chat-summary-prompt.txt
+        cat <<EOF > ./src/main/resources/chat-summary-prompt.txt
+        ${{ secrets.CHAT_SUMMARY_PROMPT }}
+        EOF
       shell: bash
 
     - name: make memo-summary-prompt.txt

--- a/src/main/java/corecord/dev/domain/auth/service/TokenService.java
+++ b/src/main/java/corecord/dev/domain/auth/service/TokenService.java
@@ -60,6 +60,7 @@ public class TokenService {
 
         // 새 AccessToken 발급
         String accessToken = jwtUtil.generateAccessToken(userId);
+        log.info("AccessToken: {}", accessToken);
 
         // 쿠키에 AccessToken 및 RefreshToken 추가
         setTokenCookies(response, "refreshToken", refreshToken);
@@ -92,6 +93,7 @@ public class TokenService {
 
         // 쿠키에 새 AccessToken 추가
         setTokenCookies(response, "accessToken", newAccessToken);
+        log.info("AccessToken: {}", newAccessToken);
 
         User user = findUserById(userId);
         return UserConverter.toUserDto(user);

--- a/src/main/java/corecord/dev/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/corecord/dev/domain/chat/converter/ChatConverter.java
@@ -1,6 +1,7 @@
 package corecord.dev.domain.chat.converter;
 
 import corecord.dev.domain.chat.dto.response.ChatResponse;
+import corecord.dev.domain.chat.dto.response.ChatSummaryAiResponse;
 import corecord.dev.domain.chat.entity.Chat;
 import corecord.dev.domain.chat.entity.ChatRoom;
 import corecord.dev.domain.user.entity.User;
@@ -53,10 +54,11 @@ public class ChatConverter {
                 .build();
     }
 
-    public static ChatResponse.ChatSummaryDto toChatSummaryDto(ChatRoom chatRoom, String content) {
+    public static ChatResponse.ChatSummaryDto toChatSummaryDto(ChatRoom chatRoom, ChatSummaryAiResponse response) {
         return ChatResponse.ChatSummaryDto.builder()
                 .chatRoomId(chatRoom.getChatRoomId())
-                .content(content)
+                .title(response.getTitle())
+                .content(response.getContent())
                 .build();
     }
 

--- a/src/main/java/corecord/dev/domain/chat/dto/response/ChatResponse.java
+++ b/src/main/java/corecord/dev/domain/chat/dto/response/ChatResponse.java
@@ -52,6 +52,7 @@ public class ChatResponse {
     @Data
     public static class ChatSummaryDto {
         private Long chatRoomId;
+        private String title;
         private String content;
     }
 

--- a/src/main/java/corecord/dev/domain/chat/dto/response/ChatSummaryAiResponse.java
+++ b/src/main/java/corecord/dev/domain/chat/dto/response/ChatSummaryAiResponse.java
@@ -1,0 +1,18 @@
+package corecord.dev.domain.chat.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Map;
+
+@Getter
+@Setter
+@Data
+public class ChatSummaryAiResponse {
+    @JsonProperty("title")
+    private String title;
+    @JsonProperty("content")
+    private String content;
+}

--- a/src/main/java/corecord/dev/domain/chat/exception/enums/ChatErrorStatus.java
+++ b/src/main/java/corecord/dev/domain/chat/exception/enums/ChatErrorStatus.java
@@ -9,10 +9,10 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ChatErrorStatus implements BaseErrorStatus {
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "E0302_CHAT_ROOM_NOT_FOUND", "존재하지 않는 채팅방입니다."),
-    CHAT_AI_RESPONSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E0302_CHAT_AI_RESPONSE_ERROR", "AI 응답 생성 중 오류가 발생했습니다."),
-    CHAT_CLIENT_ERROR(HttpStatus.BAD_REQUEST, "E0302_CHAT_CLIENT_ERROR", "AI 클라이언트 요청 오류가 발생했습니다."),
-    CHAT_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E0302_CHAT_SERVER_ERROR", "AI 서버에 오류가 발생했습니다."),
-    CREATE_SUMMARY_ERROR(HttpStatus.BAD_REQUEST, "E0305_CREATE_SUMMARY_ERROR", "경험 기록의 내용이 충분하지 않습니다."),
+    OVERFLOW_SUMMARY_TITLE(HttpStatus.BAD_REQUEST, "E0305_OVERFLOW_SUMMARY_TITLE", "경험 제목은 50자 이내여야 합니다."),
+    OVERFLOW_SUMMARY_CONTENT(HttpStatus.BAD_REQUEST, "E0305_OVERFLOW_SUMMARY_CONTENT", "경험 요약 내용은 500자 이내여야 합니다."),
+    INVALID_CHAT_SUMMARY(HttpStatus.BAD_REQUEST, "E0305_INVALID_CHAT_SUMMARY", "채팅 경험 요약 파싱 중 오류가 발생했습니다."),
+    NO_RECORD(HttpStatus.BAD_REQUEST, "E0305_NO_RECORD", "경험 기록의 내용이 충분하지 않습니다."),
     TMP_CHAT_EXIST(HttpStatus.BAD_REQUEST, "E0307_TMP_CHAT_EXIST", "임시 채팅이 이미 존재합니다."),;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/corecord/dev/domain/chat/exception/enums/ChatErrorStatus.java
+++ b/src/main/java/corecord/dev/domain/chat/exception/enums/ChatErrorStatus.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ChatErrorStatus implements BaseErrorStatus {
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "E0302_CHAT_ROOM_NOT_FOUND", "존재하지 않는 채팅방입니다."),
-    OVERFLOW_SUMMARY_TITLE(HttpStatus.BAD_REQUEST, "E0305_OVERFLOW_SUMMARY_TITLE", "경험 제목은 50자 이내여야 합니다."),
+    OVERFLOW_SUMMARY_TITLE(HttpStatus.BAD_REQUEST, "E0305_OVERFLOW_SUMMARY_TITLE", "경험 제목은 30자 이내여야 합니다."),
     OVERFLOW_SUMMARY_CONTENT(HttpStatus.BAD_REQUEST, "E0305_OVERFLOW_SUMMARY_CONTENT", "경험 요약 내용은 500자 이내여야 합니다."),
     INVALID_CHAT_SUMMARY(HttpStatus.BAD_REQUEST, "E0305_INVALID_CHAT_SUMMARY", "채팅 경험 요약 파싱 중 오류가 발생했습니다."),
     NO_RECORD(HttpStatus.BAD_REQUEST, "E0305_NO_RECORD", "경험 기록의 내용이 충분하지 않습니다."),

--- a/src/main/java/corecord/dev/domain/chat/service/ChatService.java
+++ b/src/main/java/corecord/dev/domain/chat/service/ChatService.java
@@ -1,10 +1,20 @@
 package corecord.dev.domain.chat.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import corecord.dev.common.exception.GeneralException;
 import corecord.dev.common.status.ErrorStatus;
+import corecord.dev.domain.analysis.constant.Keyword;
+import corecord.dev.domain.analysis.converter.AnalysisConverter;
+import corecord.dev.domain.analysis.dto.response.AnalysisAiResponse;
+import corecord.dev.domain.analysis.entity.Ability;
+import corecord.dev.domain.analysis.entity.Analysis;
+import corecord.dev.domain.analysis.exception.enums.AnalysisErrorStatus;
+import corecord.dev.domain.analysis.exception.model.AnalysisException;
 import corecord.dev.domain.chat.converter.ChatConverter;
 import corecord.dev.domain.chat.dto.request.ChatRequest;
 import corecord.dev.domain.chat.dto.response.ChatResponse;
+import corecord.dev.domain.chat.dto.response.ChatSummaryAiResponse;
 import corecord.dev.domain.chat.entity.Chat;
 import corecord.dev.domain.chat.entity.ChatRoom;
 import corecord.dev.domain.chat.exception.enums.ChatErrorStatus;
@@ -19,6 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 
 @Service
 @Slf4j
@@ -113,13 +124,16 @@ public class ChatService {
         List<Chat> chatList = chatRepository.findByChatRoomOrderByChatId(chatRoom);
 
         // 사용자 입력 없이 저장하려는 경우
-        validateChatList(chatList.size() <= 1);
+        validateChatList(chatList);
 
         // 채팅 정보 요약 생성
-        String summary = generateChatSummary(chatList);
-        validateSummaryContent(summary);
+        ChatSummaryAiResponse response = generateChatSummary(chatList);
+        log.info(">>>>파싱 끝");
+        log.info(response.getTitle());
+        log.info(response.getContent());
+        validateResponse(response);
 
-        return ChatConverter.toChatSummaryDto(chatRoom, summary);
+        return ChatConverter.toChatSummaryDto(chatRoom, response);
     }
 
     /*
@@ -156,19 +170,41 @@ public class ChatService {
         user.updateTmpChat(chatRoom.getChatRoomId());
     }
 
-    private static void validateChatList(boolean chatList) {
-        if (chatList) {
+    private static void validateResponse(ChatSummaryAiResponse response) {
+        if (response.getTitle().equals("NO_RECORD") || response.getContent().equals("NO_RECORD") || response.getContent().equals("") || response.getTitle().equals("")) {
+            throw new ChatException(ChatErrorStatus.CREATE_SUMMARY_ERROR);
+        }
+
+        if (response.getTitle().length() > 15) {
+            throw new ChatException(ChatErrorStatus.CREATE_SUMMARY_ERROR);
+        }
+
+        if (response.getContent().length() > 500) {
             throw new ChatException(ChatErrorStatus.CREATE_SUMMARY_ERROR);
         }
     }
 
-    private static void validateSummaryContent(String summary) {
-        validateChatList(summary.equals("NO_RECORD"));
+    private static void validateChatList(List<Chat> chatList) {
+        if(chatList.size() <= 1) {
+            throw new ChatException(ChatErrorStatus.CREATE_SUMMARY_ERROR);
+        }
     }
 
-    private String generateChatSummary(List<Chat> chatList) {
+    private ChatSummaryAiResponse generateChatSummary(List<Chat> chatList) {
         ClovaRequest clovaRequest = ClovaRequest.createChatSummaryRequest(chatList);
-        return clovaService.generateAiResponse(clovaRequest);
+        String response = clovaService.generateAiResponse(clovaRequest);
+        log.info("response: {}", response);
+        return parseChatSummaryResponse(response);
+    }
+
+    private ChatSummaryAiResponse parseChatSummaryResponse(String aiResponse) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            log.error(">>>Parsing");
+            return objectMapper.readValue(aiResponse, ChatSummaryAiResponse.class);
+        } catch (JsonProcessingException e) {
+            throw new ChatException(ChatErrorStatus.CREATE_SUMMARY_ERROR);
+        }
     }
 
     private void checkTmpChat(User user, ChatRoom chatRoom) {


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #74 

### 💡 작업내용
- 채팅 경험 요약 시 제목 자동 생성 기능 추가했습니다.
- 채팅 관련 ErrorStatus 정리했습니다.

### 📸 스크린샷(선택)
<img width="1227" alt="image" src="https://github.com/user-attachments/assets/c127e780-0994-40ea-ba25-a324fafbdcf3">


### 📝 기타
- Clova Studio 그대로 사용했습니다.
- chat-summary-prompt.txt 수정되었으니 노션 참고 부탁드립니다.
- 개발환경에서 발급된 AccessToken 쿠키에서 보기 어려워서 콘솔로 볼 수 있게 log 추가했습니다.