### PR TITLE
[Refactor/#70] 회원 탈퇴 기능 쿼리 개선

### DIFF
--- a/src/main/java/corecord/dev/domain/analysis/dto/response/AnalysisResponse.java
+++ b/src/main/java/corecord/dev/domain/analysis/dto/response/AnalysisResponse.java
@@ -48,12 +48,12 @@ public class AnalysisResponse {
     public static class KeywordStateDto {
         private String keyword;
         private Long count;
-        private String percent;
+        private Long percent;
 
         public KeywordStateDto(Keyword keyword, Long count, Double percent) {
             this.keyword = keyword.getValue();
             this.count = count;
-            this.percent = Math.round(percent) + "%";
+            this.percent = Math.round(percent);
         }
     }
 

--- a/src/main/java/corecord/dev/domain/analysis/repository/AbilityRepository.java
+++ b/src/main/java/corecord/dev/domain/analysis/repository/AbilityRepository.java
@@ -4,6 +4,7 @@ import corecord.dev.domain.analysis.dto.response.AnalysisResponse;
 import corecord.dev.domain.analysis.entity.Ability;
 import corecord.dev.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -20,4 +21,10 @@ public interface AbilityRepository extends JpaRepository<Ability, Long> {
                 "GROUP BY a.keyword " +
                 "ORDER BY 3 desc ") // 비율 높은 순 정렬
         List<AnalysisResponse.KeywordStateDto> findKeywordStateDtoList(@Param(value = "user") User user);
+
+        @Modifying
+        @Query("DELETE " +
+                "FROM Ability a " +
+                "WHERE a.user.userId IN :userId")
+        void deleteAbilityByUserId(@Param(value = "userId") Long userId);
 }

--- a/src/main/java/corecord/dev/domain/analysis/repository/AnalysisRepository.java
+++ b/src/main/java/corecord/dev/domain/analysis/repository/AnalysisRepository.java
@@ -4,6 +4,7 @@ import corecord.dev.domain.analysis.constant.Keyword;
 import corecord.dev.domain.analysis.entity.Analysis;
 import corecord.dev.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -28,4 +29,10 @@ public interface AnalysisRepository extends JpaRepository<Analysis, Long> {
             "GROUP BY a.keyword " +
             "ORDER BY COUNT(a.keyword) DESC, MAX(ana.createdAt) DESC ") // 개수가 많은 순, 최근 생성 순 정렬
     List<Keyword> getKeywordList(@Param(value = "user") User user);
+
+    @Modifying
+    @Query("DELETE " +
+            "FROM Analysis a " +
+            "WHERE a.record.user.userId IN :userId")
+    void deleteAnalysisByUserId(@Param(value = "userId") Long userId);
 }

--- a/src/main/java/corecord/dev/domain/folder/repository/FolderRepository.java
+++ b/src/main/java/corecord/dev/domain/folder/repository/FolderRepository.java
@@ -4,6 +4,7 @@ import corecord.dev.domain.folder.dto.response.FolderResponse;
 import corecord.dev.domain.folder.entity.Folder;
 import corecord.dev.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -28,4 +29,10 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
             @Param(value = "user") User user);
 
     boolean existsByTitle(String title);
+
+    @Modifying
+    @Query("DELETE " +
+            "FROM Folder f " +
+            "WHERE f.user.userId IN :userId")
+    void deleteFolderByUserId(@Param(value = "userId") Long userId);
 }

--- a/src/main/java/corecord/dev/domain/record/repository/RecordRepository.java
+++ b/src/main/java/corecord/dev/domain/record/repository/RecordRepository.java
@@ -6,6 +6,7 @@ import corecord.dev.domain.record.entity.Record;
 import corecord.dev.domain.user.entity.User;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -79,4 +80,10 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
             "FROM Record r " +
             "WHERE r.user = :user")
     int getRecordCount(@Param(value = "user") User user);
+
+    @Modifying
+    @Query("DELETE " +
+            "FROM Record r " +
+            "WHERE r.user.userId IN :userId")
+    void deleteRecordByUserId(@Param(value = "userId") Long userId);
 }

--- a/src/main/java/corecord/dev/domain/user/entity/User.java
+++ b/src/main/java/corecord/dev/domain/user/entity/User.java
@@ -39,16 +39,16 @@ public class User extends BaseEntity {
     @Column
     private Long tmpMemo;
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<Record> records;
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<ChatRoom> chatRooms;
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<Ability> abilities;
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<Folder> folders;
 
     public void updateTmpMemo(Long tmpMemo) {

--- a/src/main/java/corecord/dev/domain/user/repository/UserRepository.java
+++ b/src/main/java/corecord/dev/domain/user/repository/UserRepository.java
@@ -2,6 +2,9 @@ package corecord.dev.domain.user.repository;
 
 import corecord.dev.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -10,4 +13,9 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByProviderId(String providerId);
     boolean existsByProviderId(String providerId);
+
+    @Modifying
+    @Query("DELETE FROM User u " +
+            "WHERE u.userId = :userId")
+    void deleteUserByUserId(@Param(value = "userId") Long userId);
 }

--- a/src/main/java/corecord/dev/domain/user/service/UserService.java
+++ b/src/main/java/corecord/dev/domain/user/service/UserService.java
@@ -4,6 +4,9 @@ import corecord.dev.common.exception.GeneralException;
 import corecord.dev.common.status.ErrorStatus;
 import corecord.dev.common.util.CookieUtil;
 import corecord.dev.common.util.JwtUtil;
+import corecord.dev.domain.analysis.repository.AbilityRepository;
+import corecord.dev.domain.analysis.repository.AnalysisRepository;
+import corecord.dev.domain.folder.repository.FolderRepository;
 import corecord.dev.domain.record.repository.RecordRepository;
 import corecord.dev.domain.auth.entity.RefreshToken;
 import corecord.dev.domain.auth.exception.enums.TokenErrorStatus;
@@ -39,6 +42,9 @@ public class UserService {
     private final UserRepository userRepository;
     private final RecordRepository recordRepository;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final FolderRepository folderRepository;
+    private final AnalysisRepository analysisRepository;
+    private final AbilityRepository abilityRepository;
 
     @Value("${jwt.access-token.expiration-time}")
     private long accessTokenExpirationTime;
@@ -83,8 +89,12 @@ public class UserService {
     // 유저 삭제
     @Transactional
     public void deleteUser(HttpServletRequest request, HttpServletResponse response, Long userId) {
-        // 유저 삭제
-        userRepository.deleteById(userId);
+        // 연관된 데이터 삭제
+        abilityRepository.deleteAbilityByUserId(userId);
+        analysisRepository.deleteAnalysisByUserId(userId);
+        recordRepository.deleteRecordByUserId(userId);
+        folderRepository.deleteFolderByUserId(userId);
+        userRepository.deleteUserByUserId(userId);
 
         // RefreshToken 삭제
         deleteRefreshTokenInRedis(request);


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #70 

### 💡 작업내용
- 회원 탈퇴 기능 쿼리 개선
- 기존 select + delete N + N + N + N + 1 개 나가던 쿼리를 delete 5개로 개선
- `@Modifying` annotation 사용
- 각 도메인의 repository에서 delete func 생성 후 호출
  - userId 비교 `=` 대신 `IN` 연산자 사용 
- 역량 키워드 그래프 percent field 반환값 변경
  - String(`'%'`) -> Long  

### 📸 스크린샷(선택)
<img width="1170" alt="스크린샷 2024-11-11 오전 5 01 02" src="https://github.com/user-attachments/assets/625e0870-24e9-46d1-9e39-03385187c30f">


### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
- `@EntityGraph`를 통해 2개 이상의 List를 한 번에 가져오면 Multibag 오류가 생긴다는 점을 알게 되었습니다 🤩
