### PR TITLE
[Chore/#90] 경험 기록 리스트 반환 개수 수정 & 메모 임시 저장 내역 조회 오류 해결

### DIFF
--- a/src/main/java/corecord/dev/domain/ability/service/AbilityService.java
+++ b/src/main/java/corecord/dev/domain/ability/service/AbilityService.java
@@ -76,6 +76,7 @@ public class AbilityService {
         }
     }
 
+    @Transactional
     public void deleteOriginAbilityList(Analysis analysis) {
         List<Ability> abilityList = analysis.getAbilityList();
 

--- a/src/main/java/corecord/dev/domain/analysis/service/AnalysisService.java
+++ b/src/main/java/corecord/dev/domain/analysis/service/AnalysisService.java
@@ -98,7 +98,6 @@ public class AnalysisService {
      * @param recordId
      * @return
      */
-    @Transactional
     public AnalysisResponse.AnalysisDto postAnalysis(Long userId, Long recordId) {
         User user = findUserById(userId);
         Record record = findRecordById(recordId);

--- a/src/main/java/corecord/dev/domain/record/service/RecordService.java
+++ b/src/main/java/corecord/dev/domain/record/service/RecordService.java
@@ -43,7 +43,7 @@ public class RecordService {
     private final UserRepository userRepository;
     private final AnalysisService analysisService;
     private final ChatRoomRepository chatRoomRepository;
-    private final int listSize = 20;
+    private final int listSize = 30;
 
     /*
      * user의 MEMO ver. 경험을 기록하고 폴더를 지정한 후 생성된 경험 기록 정보를 반환
@@ -126,7 +126,7 @@ public class RecordService {
         }
 
         // 임시 저장 내역이 있는 경우 결과 조회
-        Record tmpMemoRecord = findRecordById(tmpMemoRecordId);
+        Record tmpMemoRecord = findTmpRecordById(tmpMemoRecordId);
 
         // 기존 데이터 제거 후 결과 반환
         user.deleteTmpMemo();
@@ -248,6 +248,11 @@ public class RecordService {
                 .orElseThrow(() -> new RecordException(RecordErrorStatus.RECORD_NOT_FOUND));
     }
 
+    private Record findTmpRecordById(Long recordId) {
+        return recordRepository.findById(recordId)
+                .orElseThrow(() -> new RecordException(RecordErrorStatus.RECORD_NOT_FOUND));
+    }
+
     private List<Record> findRecordListByFolder(User user, Folder folder, Long lastRecordId) {
         Pageable pageable = PageRequest.of(0, listSize + 1, Sort.by("createdAt").descending());
         return recordRepository.findRecordsByFolder(folder, user, lastRecordId, pageable);
@@ -259,7 +264,7 @@ public class RecordService {
     }
 
     private List<Record> findRecordListOrderByCreatedAt(User user) {
-        Pageable pageable = PageRequest.of(0, 3, Sort.by("createdAt").descending());
+        Pageable pageable = PageRequest.of(0, 9, Sort.by("createdAt").descending());
         return recordRepository.findRecordsOrderByCreatedAt(user, pageable);
     }
 


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #90 

### 💡 작업내용
- 불필요한 Transaction annotation 제거
- 리스트 반환 개수 변환
  - 경험 기록 리스트 : 20 -> 30
  - 홈 : 3 -> 9 
- 메모 임시 저장 내역 조회 오류 해결

### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
