### PR TITLE
[Test/#94] Analysis, Ability 도메인 관련 테스트 코드 작성

### DIFF
--- a/src/main/java/corecord/dev/domain/ability/exception/enums/AbilityErrorStatus.java
+++ b/src/main/java/corecord/dev/domain/ability/exception/enums/AbilityErrorStatus.java
@@ -8,7 +8,10 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum AbilityErrorStatus implements BaseErrorStatus {
-    INVALID_KEYWORD(HttpStatus.BAD_REQUEST, "E400_INVALID_KEYWORD", "역량 분석에 존재하지 않는 키워드입니다.");
+    INVALID_KEYWORD(HttpStatus.BAD_REQUEST, "E400_INVALID_KEYWORD", "역량 분석에 존재하지 않는 키워드입니다."),
+    INVALID_ABILITY_KEYWORD(HttpStatus.INTERNAL_SERVER_ERROR, "E500_INVALID_ABILITY_KEYWORD", "역량 키워드 파싱 중 오류가 발생했습니다."),
+    ;
+
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/corecord/dev/domain/ability/service/AbilityService.java
+++ b/src/main/java/corecord/dev/domain/ability/service/AbilityService.java
@@ -6,10 +6,10 @@ import corecord.dev.domain.ability.converter.AbilityConverter;
 import corecord.dev.domain.ability.dto.response.AbilityResponse;
 import corecord.dev.domain.ability.entity.Ability;
 import corecord.dev.domain.ability.entity.Keyword;
+import corecord.dev.domain.ability.exception.enums.AbilityErrorStatus;
+import corecord.dev.domain.ability.exception.model.AbilityException;
 import corecord.dev.domain.ability.repository.AbilityRepository;
 import corecord.dev.domain.analysis.entity.Analysis;
-import corecord.dev.domain.analysis.exception.enums.AnalysisErrorStatus;
-import corecord.dev.domain.analysis.exception.model.AnalysisException;
 import corecord.dev.domain.user.entity.User;
 import corecord.dev.domain.user.repository.UserRepository;
 import jakarta.persistence.EntityManager;
@@ -72,7 +72,7 @@ public class AbilityService {
         }
 
         if (abilityCount < 1 || abilityCount > 3) {
-            throw new AnalysisException(AnalysisErrorStatus.INVALID_ABILITY_ANALYSIS);
+            throw new AbilityException(AbilityErrorStatus.INVALID_ABILITY_KEYWORD);
         }
     }
 

--- a/src/main/java/corecord/dev/domain/analysis/dto/request/AnalysisRequest.java
+++ b/src/main/java/corecord/dev/domain/analysis/dto/request/AnalysisRequest.java
@@ -1,13 +1,14 @@
 package corecord.dev.domain.analysis.dto.request;
 
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 import lombok.Data;
 
 import java.util.Map;
 
 public class AnalysisRequest {
 
-    @Data
+    @Data @Builder
     public static class AnalysisUpdateDto {
         @NotNull(message = "역량 분석 id를 입력해주세요.")
         private Long analysisId;

--- a/src/main/java/corecord/dev/domain/analysis/dto/response/AnalysisAiResponse.java
+++ b/src/main/java/corecord/dev/domain/analysis/dto/response/AnalysisAiResponse.java
@@ -1,6 +1,7 @@
 package corecord.dev.domain.analysis.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
@@ -9,6 +10,7 @@ import java.util.Map;
 
 @Setter
 @Getter @Data
+@AllArgsConstructor
 public class AnalysisAiResponse {
     @JsonProperty("keywordList")
     private Map<String, String> keywordList;

--- a/src/main/java/corecord/dev/domain/analysis/exception/enums/AnalysisErrorStatus.java
+++ b/src/main/java/corecord/dev/domain/analysis/exception/enums/AnalysisErrorStatus.java
@@ -13,7 +13,7 @@ public enum AnalysisErrorStatus implements BaseErrorStatus {
     OVERFLOW_ANALYSIS_KEYWORD_CONTENT(HttpStatus.BAD_REQUEST, "E0400_OVERFLOW_KEYWORD_CONTENT", "경험 기록 키워드별 내용은 200자 이내여야 합니다."),
     USER_ANALYSIS_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "E401_ANALYSIS_UNAUTHORIZED", "유저가 역량 분석에 대한 권한이 없습니다."),
     ANALYSIS_NOT_FOUND(HttpStatus.NOT_FOUND, "E0404_ANALYSIS", "존재하지 않는 역량 분석입니다."),
-    INVALID_ABILITY_ANALYSIS(HttpStatus.BAD_REQUEST, "E400_INVALID_ANALYSIS", "역량 분석 데이터 파싱 중 오류가 발생했습니다."),
+    INVALID_ABILITY_ANALYSIS(HttpStatus.INTERNAL_SERVER_ERROR, "E500_INVALID_ANALYSIS", "역량 분석 데이터 파싱 중 오류가 발생했습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/test/java/corecord/dev/ability/service/AbilityServiceTest.java
+++ b/src/test/java/corecord/dev/ability/service/AbilityServiceTest.java
@@ -1,0 +1,186 @@
+package corecord.dev.ability.service;
+
+import corecord.dev.domain.ability.dto.response.AbilityResponse;
+import corecord.dev.domain.ability.entity.Ability;
+import corecord.dev.domain.ability.entity.Keyword;
+import corecord.dev.domain.ability.exception.enums.AbilityErrorStatus;
+import corecord.dev.domain.ability.exception.model.AbilityException;
+import corecord.dev.domain.ability.repository.AbilityRepository;
+import corecord.dev.domain.ability.service.AbilityService;
+import corecord.dev.domain.analysis.entity.Analysis;
+import corecord.dev.domain.folder.entity.Folder;
+import corecord.dev.domain.record.constant.RecordType;
+import corecord.dev.domain.record.entity.Record;
+import corecord.dev.domain.user.entity.Status;
+import corecord.dev.domain.user.entity.User;
+import corecord.dev.domain.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class AbilityServiceTest {
+
+    @Mock
+    EntityManager entityManager;
+
+    @Mock
+    UserRepository userRepository;
+
+    @Mock
+    AbilityRepository abilityRepository;
+
+    @InjectMocks
+    AbilityService abilityService;
+
+    private User user;
+    private Folder folder;
+    private Record record;
+    private Analysis analysis;
+    private String testKeywordComment = "Test Keyword Comment";
+
+    @BeforeEach
+    void setUp() {
+        user = createMockUser();
+        folder = createMockFolder(user);
+        record = createMockRecord(user, folder);
+        analysis = createMockAnalysis(record);
+        analysis.setCreatedAt(LocalDateTime.now());
+    }
+
+    @Test
+    @DisplayName("유저의 경험 키워드 리스트 조회 테스트")
+    void getKeywordListTest() {
+        // Given
+        Ability ability1 = createMockAbility(Keyword.COMMUNICATION, analysis);
+        Ability ability2 = createMockAbility(Keyword.LEADERSHIP, analysis);
+        analysis.addAbility(ability1);
+        analysis.addAbility(ability2);
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(abilityRepository.getKeywordList(any(User.class)))
+                .thenReturn(List.of(Keyword.COMMUNICATION, Keyword.LEADERSHIP));
+
+        // When
+        AbilityResponse.KeywordListDto response = abilityService.getKeywordList(1L);
+
+        // Then
+        verify(userRepository, times(1)).findById(1L);
+        verify(abilityRepository, times(1)).getKeywordList(user);
+
+        assertEquals(2, response.getKeywordList().size());
+        assertEquals(Keyword.COMMUNICATION.getValue(), response.getKeywordList().get(0));
+        assertEquals(Keyword.LEADERSHIP.getValue(), response.getKeywordList().get(1));
+    }
+
+    @Test
+    @DisplayName("경험 키워드 파싱 테스트")
+    void parseAndSaveAbilitiesTest() {
+        // Given
+        Map<String, String> keywordList = Map.of(
+                Keyword.COMMUNICATION.getValue(), testKeywordComment,
+                Keyword.LEADERSHIP.getValue(), testKeywordComment);
+
+        // When
+        abilityService.parseAndSaveAbilities(keywordList, analysis, user);
+
+        // Then
+        verify(abilityRepository, times(2)).save(any(Ability.class));
+        assertEquals(2, analysis.getAbilityList().size());
+        assertEquals(Keyword.COMMUNICATION.getValue(), analysis.getAbilityList().get(0).getKeyword().getValue());
+        assertEquals(Keyword.LEADERSHIP.getValue(), analysis.getAbilityList().get(1).getKeyword().getValue());
+    }
+
+    @Test
+    @DisplayName("경험 키워드 파싱 결과의 개수가 0인 경우 테스트")
+    void parseAbilityWithEmptyKeywordList() {
+        // Given
+        Map<String, String> keywordList = Map.of("Keyword", testKeywordComment);
+
+        // When & Then
+        AbilityException exception = assertThrows(AbilityException.class,
+                () -> abilityService.parseAndSaveAbilities(keywordList, analysis, user));
+        assertEquals(exception.getAbilityErrorStatus(), AbilityErrorStatus.INVALID_ABILITY_KEYWORD);
+    }
+
+    @Test
+    void deleteOriginAbilityTest() {
+        // Given
+        Ability ability1 = createMockAbility(Keyword.COMMUNICATION, analysis);
+        Ability ability2 = createMockAbility(Keyword.LEADERSHIP, analysis);
+        analysis.addAbility(ability1);
+        analysis.addAbility(ability2);
+
+        assertEquals(2, analysis.getAbilityList().size());
+
+        // When
+        abilityService.deleteOriginAbilityList(analysis);
+
+        // Then
+        assertEquals(0, analysis.getAbilityList().size());
+    }
+
+
+    private User createMockUser() {
+        return User.builder()
+                .userId(1L)
+                .providerId("Test Provider")
+                .nickName("Test User")
+                .status(Status.GRADUATE_STUDENT)
+                .folders(new ArrayList<>())
+                .build();
+    }
+
+    private Folder createMockFolder(User user) {
+        return Folder.builder()
+                .folderId(1L)
+                .title("Test Folder")
+                .user(user)
+                .build();
+    }
+
+    private Record createMockRecord(User user, Folder folder) {
+        return Record.builder()
+                .recordId(1L)
+                .title("Test Record")
+                .content("Test".repeat(10))
+                .user(user)
+                .type(RecordType.MEMO)
+                .folder(folder)
+                .build();
+    }
+
+    private Analysis createMockAnalysis(Record record) {
+        return Analysis.builder()
+                .analysisId(1L)
+                .content("Test".repeat(10))
+                .comment("Test Comment")
+                .record(record)
+                .abilityList(new ArrayList<>())
+                .build();
+    }
+
+    private Ability createMockAbility(Keyword keyword, Analysis analysis) {
+        return Ability.builder()
+                .keyword(keyword)
+                .content("Test Keyword Content")
+                .user(user)
+                .analysis(analysis)
+                .build();
+    }
+}

--- a/src/test/java/corecord/dev/analysis/service/AnalysisServiceTest.java
+++ b/src/test/java/corecord/dev/analysis/service/AnalysisServiceTest.java
@@ -1,0 +1,224 @@
+package corecord.dev.analysis.service;
+
+import corecord.dev.domain.ability.entity.Ability;
+import corecord.dev.domain.ability.entity.Keyword;
+import corecord.dev.domain.ability.service.AbilityService;
+import corecord.dev.domain.analysis.dto.response.AnalysisAiResponse;
+import corecord.dev.domain.analysis.entity.Analysis;
+import corecord.dev.domain.analysis.exception.enums.AnalysisErrorStatus;
+import corecord.dev.domain.analysis.exception.model.AnalysisException;
+import corecord.dev.domain.analysis.repository.AnalysisRepository;
+import corecord.dev.domain.analysis.service.AnalysisService;
+import corecord.dev.domain.analysis.service.OpenAiService;
+import corecord.dev.domain.folder.entity.Folder;
+import corecord.dev.domain.record.constant.RecordType;
+import corecord.dev.domain.record.entity.Record;
+import corecord.dev.domain.user.entity.Status;
+import corecord.dev.domain.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+
+public class AnalysisServiceTest {
+
+    @Mock
+    private AnalysisRepository analysisRepository;
+
+    @Mock
+    private OpenAiService openAiService;
+
+    @Mock
+    private AbilityService abilityService;
+
+    @InjectMocks
+    private AnalysisService analysisService;
+
+    private User user;
+    private Folder folder;
+    private Record record;
+
+    private String testTitle = "Test Record";
+    private String testContent = "Test".repeat(10);
+    private String testComment = "Test Comment";
+
+    @BeforeEach
+    void setUp() {
+        user = createMockUser();
+        folder = createMockFolder(user);
+        record = createMockRecord(user, folder);
+    }
+
+    @Test
+    @DisplayName("메모 역량 분석 생성 테스트")
+    void createMemoAnalysisTest() {
+        // Given
+        Analysis analysis = createMockAnalysis(record);
+
+        when(openAiService.generateMemoSummary(any(String.class))).thenReturn(testContent);
+        when(openAiService.generateAbilityAnalysis(any(String.class)))
+                .thenReturn(new AnalysisAiResponse(Map.of("커뮤니케이션", "Test Keyword Content"), "Test Comment"));
+        when(analysisRepository.save(any(Analysis.class))).thenReturn(analysis);
+        doNothing().when(abilityService).parseAndSaveAbilities(any(Map.class), any(Analysis.class), any(User.class));
+
+        // When
+        Analysis response = analysisService.createAnalysis(record, user);
+
+        // Then
+        verify(openAiService).generateMemoSummary(testContent);
+        verify(openAiService).generateAbilityAnalysis(testContent);
+        verify(analysisRepository).save(any(Analysis.class));
+
+        assertEquals(response.getContent(), testContent);
+        assertEquals(response.getComment(), testComment);
+    }
+
+    @Test
+    @DisplayName("메모 역량 분석 요약 글자수 예외 발생 테스트")
+    void createMemoAnalysisWithNotEnoughContentTest() {
+        // Given
+        String overContent = "Test".repeat(500);
+        when(openAiService.generateMemoSummary(any(String.class))).thenReturn(overContent);
+
+        // When & Then
+        AnalysisException exception = assertThrows(AnalysisException.class,
+                () -> analysisService.createAnalysis(record, user));
+        assertEquals(exception.getAnalysisErrorStatus(), AnalysisErrorStatus.OVERFLOW_ANALYSIS_CONTENT);
+    }
+
+    @Test
+    @DisplayName("메모 역량 분석 코멘트 글자수 예외 발생 테스트")
+    void createMemoAnalysisWithNotEnoughCommentTest() {
+        // Given
+        String overComment = "Test".repeat(200);
+        when(openAiService.generateMemoSummary(any(String.class))).thenReturn(testContent);
+        when(openAiService.generateAbilityAnalysis(any(String.class)))
+                .thenReturn(new AnalysisAiResponse(Map.of("커뮤니케이션", "Test Keyword Content"), overComment));
+
+        // When & Then
+        AnalysisException exception = assertThrows(AnalysisException.class,
+                () -> analysisService.createAnalysis(record, user));
+        assertEquals(exception.getAnalysisErrorStatus(), AnalysisErrorStatus.OVERFLOW_ANALYSIS_COMMENT);
+    }
+
+    @Test
+    @DisplayName("메모 역량 분석 키워드 글자수 예외 발생 테스트")
+    void createMemoAnalysisWithLongKeywordCommentTest() {
+        // Given
+        String overKeywordComment = "Test".repeat(200);
+        when(openAiService.generateMemoSummary(any(String.class))).thenReturn(testContent);
+        when(openAiService.generateAbilityAnalysis(any(String.class)))
+                .thenReturn(new AnalysisAiResponse(Map.of("커뮤니케이션", overKeywordComment), testComment));
+
+        // When & Then
+        AnalysisException exception = assertThrows(AnalysisException.class,
+                () -> analysisService.createAnalysis(record, user));
+        assertEquals(exception.getAnalysisErrorStatus(), AnalysisErrorStatus.OVERFLOW_ANALYSIS_KEYWORD_CONTENT);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 키워드 제시 시 예외 발생 테스트")
+    void findAbilityByNotExistingKeyword() {
+        // Given
+
+        // When & Then
+
+    }
+
+
+    @Test
+    @DisplayName("메모 역량 분석 재생성 테스트")
+    void recreateAnalysisTest() {
+        // Given
+        // When
+        // Then
+    }
+
+    @Test
+    @DisplayName("역량 분석 상세 정보 조회 테스트")
+    void getAnalysisDetailTest() {
+        // Given
+        // When
+        // Then
+
+    }
+
+    @Test
+    @DisplayName("역량 분석 수정 테스트")
+    void updateAnalysisTest() {
+        // Given
+        // When
+        // Then
+
+    }
+
+    @Test
+    @DisplayName("역량 분석 삭제 테스트")
+    void deleteAnalysisTest() {
+        // Given
+        // When
+        // Then
+
+    }
+
+    private User createMockUser() {
+        return User.builder()
+                .userId(1L)
+                .providerId("Test Provider")
+                .nickName("Test User")
+                .status(Status.GRADUATE_STUDENT)
+                .folders(new ArrayList<>())
+                .build();
+    }
+
+    private Folder createMockFolder(User user) {
+        return Folder.builder()
+                .folderId(1L)
+                .title("Test Folder")
+                .user(user)
+                .build();
+    }
+
+    private Record createMockRecord(User user, Folder folder) {
+        return Record.builder()
+                .recordId(1L)
+                .title(testTitle)
+                .content(testContent)
+                .user(user)
+                .type(RecordType.MEMO)
+                .folder(folder)
+                .build();
+    }
+
+    private Analysis createMockAnalysis(Record record) {
+        return Analysis.builder()
+                .analysisId(1L)
+                .content(testContent)
+                .comment(testComment)
+                .record(record)
+                .build();
+    }
+
+    private Ability createMockAbility(Analysis analysis) {
+        return Ability.builder()
+                .keyword(Keyword.COMMUNICATION)
+                .content("Test Keyword Content")
+                .user(user)
+                .analysis(analysis)
+                .build();
+    }
+
+}

--- a/src/test/java/corecord/dev/analysis/service/AnalysisServiceTest.java
+++ b/src/test/java/corecord/dev/analysis/service/AnalysisServiceTest.java
@@ -2,8 +2,12 @@ package corecord.dev.analysis.service;
 
 import corecord.dev.domain.ability.entity.Ability;
 import corecord.dev.domain.ability.entity.Keyword;
+import corecord.dev.domain.ability.exception.enums.AbilityErrorStatus;
+import corecord.dev.domain.ability.exception.model.AbilityException;
 import corecord.dev.domain.ability.service.AbilityService;
+import corecord.dev.domain.analysis.dto.request.AnalysisRequest;
 import corecord.dev.domain.analysis.dto.response.AnalysisAiResponse;
+import corecord.dev.domain.analysis.dto.response.AnalysisResponse;
 import corecord.dev.domain.analysis.entity.Analysis;
 import corecord.dev.domain.analysis.exception.enums.AnalysisErrorStatus;
 import corecord.dev.domain.analysis.exception.model.AnalysisException;
@@ -15,6 +19,7 @@ import corecord.dev.domain.record.constant.RecordType;
 import corecord.dev.domain.record.entity.Record;
 import corecord.dev.domain.user.entity.Status;
 import corecord.dev.domain.user.entity.User;
+import corecord.dev.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,8 +28,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -34,6 +41,9 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 
 public class AnalysisServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
 
     @Mock
     private AnalysisRepository analysisRepository;
@@ -50,6 +60,7 @@ public class AnalysisServiceTest {
     private User user;
     private Folder folder;
     private Record record;
+    private Analysis analysis;
 
     private String testTitle = "Test Record";
     private String testContent = "Test".repeat(10);
@@ -60,14 +71,14 @@ public class AnalysisServiceTest {
         user = createMockUser();
         folder = createMockFolder(user);
         record = createMockRecord(user, folder);
+        analysis = createMockAnalysis(record);
+        analysis.setCreatedAt(LocalDateTime.now());
     }
 
     @Test
     @DisplayName("메모 역량 분석 생성 테스트")
     void createMemoAnalysisTest() {
         // Given
-        Analysis analysis = createMockAnalysis(record);
-
         when(openAiService.generateMemoSummary(any(String.class))).thenReturn(testContent);
         when(openAiService.generateAbilityAnalysis(any(String.class)))
                 .thenReturn(new AnalysisAiResponse(Map.of("커뮤니케이션", "Test Keyword Content"), "Test Comment"));
@@ -130,48 +141,105 @@ public class AnalysisServiceTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 키워드 제시 시 예외 발생 테스트")
-    void findAbilityByNotExistingKeyword() {
+    @DisplayName("역량 분석 수정 테스트")
+    void updateAnalysisTest() {
         // Given
+        Ability ability = createMockAbility(analysis);
+        analysis.addAbility(ability);
 
-        // When & Then
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(analysisRepository.findAnalysisById(1L)).thenReturn(Optional.of(analysis));
 
+        // When
+        AnalysisRequest.AnalysisUpdateDto request = AnalysisRequest.AnalysisUpdateDto.builder()
+                .analysisId(1L)
+                .title("Updated Title")
+                .content("Updated Content".repeat(5))
+                .abilityMap(Map.of("커뮤니케이션", "Updated Keyword Content"))
+                .build();
+
+        AnalysisResponse.AnalysisDto response = analysisService.updateAnalysis(1L, request);
+
+        // Then
+        verify(userRepository, times(1)).findById(1L);
+        verify(analysisRepository, times(1)).findAnalysisById(1L);
+
+        assertEquals(response.getAnalysisId(), analysis.getAnalysisId());
+        assertEquals(response.getRecordId(), record.getRecordId());
+        assertEquals(response.getRecordTitle(), "Updated Title");
+        assertEquals(response.getRecordContent(), "Updated Content".repeat(5));
+        assertEquals(response.getComment(), analysis.getComment());
+        assertEquals(response.getAbilityDtoList().get(0).getKeyword(), "커뮤니케이션");
+        assertEquals(response.getAbilityDtoList().get(0).getContent(), "Updated Keyword Content");
     }
 
-
     @Test
-    @DisplayName("메모 역량 분석 재생성 테스트")
-    void recreateAnalysisTest() {
+    @DisplayName("역량 분석 수정 중 존재하지 않는 키워드 제시 시 예외 발생 테스트")
+    void findAbilityByNotExistingKeyword() {
         // Given
-        // When
-        // Then
+        Ability ability = createMockAbility(analysis);
+        analysis.addAbility(ability);
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(analysisRepository.findAnalysisById(1L)).thenReturn(Optional.of(analysis));
+
+        // When & Then
+        AnalysisRequest.AnalysisUpdateDto request = AnalysisRequest.AnalysisUpdateDto.builder()
+                .analysisId(1L)
+                .abilityMap(Map.of("협동", testContent))
+                .build();
+
+        AbilityException exception = assertThrows(AbilityException.class,
+                () -> analysisService.updateAnalysis(1L, request));
+
+        assertEquals(exception.getAbilityErrorStatus(), AbilityErrorStatus.INVALID_KEYWORD);
+        verify(userRepository, times(1)).findById(1L);
+        verify(analysisRepository, times(1)).findAnalysisById(1L);
     }
 
     @Test
     @DisplayName("역량 분석 상세 정보 조회 테스트")
     void getAnalysisDetailTest() {
         // Given
+        Ability ability = createMockAbility(analysis);
+        analysis.addAbility(ability);
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(analysisRepository.findAnalysisById(1L)).thenReturn(Optional.of(analysis));
+
         // When
+        AnalysisResponse.AnalysisDto response = analysisService.getAnalysis(1L, 1L);
+
         // Then
+        verify(userRepository, times(1)).findById(1L);
+        verify(analysisRepository, times(1)).findAnalysisById(1L);
 
-    }
-
-    @Test
-    @DisplayName("역량 분석 수정 테스트")
-    void updateAnalysisTest() {
-        // Given
-        // When
-        // Then
-
+        assertEquals(response.getAnalysisId(), analysis.getAnalysisId());
+        assertEquals(response.getRecordId(), record.getRecordId());
+        assertEquals(response.getRecordTitle(), testTitle);
+        assertEquals(response.getRecordContent(), testContent);
+        assertEquals(response.getComment(), testComment);
+        assertEquals(response.getAbilityDtoList().get(0).getKeyword(), "커뮤니케이션");
+        assertEquals(response.getAbilityDtoList().get(0).getContent(), "Test Keyword Content");
     }
 
     @Test
     @DisplayName("역량 분석 삭제 테스트")
     void deleteAnalysisTest() {
         // Given
-        // When
-        // Then
+        Ability ability = createMockAbility(analysis);
+        analysis.addAbility(ability);
 
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(analysisRepository.findAnalysisById(1L)).thenReturn(Optional.of(analysis));
+
+        // When
+        analysisService.deleteAnalysis(1L, 1L);
+
+        // Then
+        verify(userRepository, times(1)).findById(1L);
+        verify(analysisRepository, times(1)).findAnalysisById(1L);
+        verify(analysisRepository).delete(analysis);
     }
 
     private User createMockUser() {
@@ -209,6 +277,7 @@ public class AnalysisServiceTest {
                 .content(testContent)
                 .comment(testComment)
                 .record(record)
+                .abilityList(new ArrayList<>())
                 .build();
     }
 


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #94 

### 💡 작업내용
- `Analysis` service 단위 테스트 진행
- `Ability` service 단위 테스트 진행
- AnalysisErrorStatus enum 변경 (INVALID_KEYWORD -> INVALID_ABILITY_KEYWORD)
  - AbilityErrorStatus로 위치 변경 

### 📸 스크린샷(선택)

<img width="538" alt="스크린샷 2024-11-19 오후 4 56 21" src="https://github.com/user-attachments/assets/e44fe677-26bd-4618-bfc7-86bc9a0b0a24">
<img width="505" alt="스크린샷 2024-11-19 오후 4 56 34" src="https://github.com/user-attachments/assets/2c96c05c-a831-4bca-ae95-34884477219a">

### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
