### PR TITLE
[Refactor/#103] 외부 API 호출 Transaction 분리 & 도메인별 DBService 생성

### DIFF
--- a/src/main/java/corecord/dev/domain/ability/application/AbilityDbService.java
+++ b/src/main/java/corecord/dev/domain/ability/application/AbilityDbService.java
@@ -1,0 +1,43 @@
+package corecord.dev.domain.ability.application;
+
+import corecord.dev.domain.ability.domain.dto.response.AbilityResponse;
+import corecord.dev.domain.ability.domain.entity.Ability;
+import corecord.dev.domain.ability.domain.entity.Keyword;
+import corecord.dev.domain.ability.domain.repository.AbilityRepository;
+import corecord.dev.domain.user.domain.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AbilityDbService {
+    private final AbilityRepository abilityRepository;
+
+    @Transactional
+    public void saveAbility(Ability ability) {
+        abilityRepository.save(ability);
+    }
+
+    @Transactional
+    public void deleteAbilityByUserId(Long userId) {
+        abilityRepository.deleteAbilityByUserId(userId);
+    }
+
+    @Transactional
+    public void deleteAbilityList(List<Ability> abilityList) {
+        abilityRepository.deleteAll(abilityList);
+    }
+
+    public List<AbilityResponse.KeywordStateDto> findKeywordGraph(User user) {
+        return abilityRepository.findKeywordStateDtoList(user);
+    }
+
+    public List<String> findKeywordList(User user) {
+        return abilityRepository.getKeywordList(user).stream()
+                .map(Keyword::getValue)
+                .toList();
+    }
+}

--- a/src/main/java/corecord/dev/domain/analysis/application/AnalysisDbService.java
+++ b/src/main/java/corecord/dev/domain/analysis/application/AnalysisDbService.java
@@ -1,0 +1,47 @@
+package corecord.dev.domain.analysis.application;
+
+import corecord.dev.domain.analysis.domain.entity.Analysis;
+import corecord.dev.domain.analysis.domain.repository.AnalysisRepository;
+import corecord.dev.domain.analysis.exception.AnalysisException;
+import corecord.dev.domain.analysis.status.AnalysisErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@Service
+@RequiredArgsConstructor
+public class AnalysisDbService {
+    private final AnalysisRepository analysisRepository;
+
+    @Transactional
+    public void saveAnalysis(Analysis analysis) {
+        analysisRepository.save(analysis);
+    }
+
+    @Transactional
+    public void updateAnalysisContent(Analysis analysis, String content) {
+        analysis.updateContent(content);
+    }
+
+    @Transactional
+    public void updateAnalysisComment(Analysis analysis, String comment) {
+        analysis.updateComment(comment);
+    }
+
+    @Transactional
+    public void deleteAnalysis(Analysis analysis) {
+        analysisRepository.delete(analysis);
+    }
+
+    @Transactional
+    public void deleteAnalysisByUserId(Long userId) {
+        analysisRepository.deleteAnalysisByUserId(userId);
+    }
+
+    public Analysis findAnalysisById(Long analysisId) {
+        return analysisRepository.findAnalysisById(analysisId)
+                .orElseThrow(() -> new AnalysisException(AnalysisErrorStatus.ANALYSIS_NOT_FOUND));
+    }
+
+}

--- a/src/main/java/corecord/dev/domain/analysis/application/AnalysisService.java
+++ b/src/main/java/corecord/dev/domain/analysis/application/AnalysisService.java
@@ -21,7 +21,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Map;
 
-@Transactional(readOnly = true)
 @Service
 @RequiredArgsConstructor
 public class AnalysisService {

--- a/src/main/java/corecord/dev/domain/analysis/application/AnalysisService.java
+++ b/src/main/java/corecord/dev/domain/analysis/application/AnalysisService.java
@@ -1,27 +1,20 @@
 package corecord.dev.domain.analysis.application;
 
-import corecord.dev.common.exception.GeneralException;
-import corecord.dev.common.status.ErrorStatus;
-import corecord.dev.domain.ability.domain.entity.Keyword;
-import corecord.dev.domain.ability.status.AbilityErrorStatus;
-import corecord.dev.domain.ability.exception.AbilityException;
 import corecord.dev.domain.ability.application.AbilityService;
 import corecord.dev.domain.analysis.domain.converter.AnalysisConverter;
 import corecord.dev.domain.analysis.domain.dto.request.AnalysisRequest;
 import corecord.dev.domain.analysis.infra.openai.dto.response.AnalysisAiResponse;
 import corecord.dev.domain.analysis.domain.dto.response.AnalysisResponse;
-import corecord.dev.domain.ability.domain.entity.Ability;
 import corecord.dev.domain.analysis.domain.entity.Analysis;
 import corecord.dev.domain.analysis.infra.openai.application.OpenAiService;
 import corecord.dev.domain.analysis.status.AnalysisErrorStatus;
 import corecord.dev.domain.analysis.exception.AnalysisException;
-import corecord.dev.domain.analysis.domain.repository.AnalysisRepository;
+import corecord.dev.domain.record.application.RecordDbService;
 import corecord.dev.domain.record.domain.entity.Record;
 import corecord.dev.domain.record.status.RecordErrorStatus;
 import corecord.dev.domain.record.exception.RecordException;
-import corecord.dev.domain.record.domain.repository.RecordRepository;
+import corecord.dev.domain.user.application.UserDbService;
 import corecord.dev.domain.user.domain.entity.User;
-import corecord.dev.domain.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,12 +25,11 @@ import java.util.Map;
 @Service
 @RequiredArgsConstructor
 public class AnalysisService {
-    private final AnalysisRepository analysisRepository;
-    private final UserRepository userRepository;
-    private final RecordRepository recordRepository;
     private final OpenAiService openAiService;
     private final AbilityService abilityService;
-
+    private final AnalysisDbService analysisDbService;
+    private final UserDbService userDbService;
+    private final RecordDbService recordDbService;
 
     /*
      * CLOVA STUDIO룰 활용해 역량 분석 객체를 생성 후 반환
@@ -45,7 +37,6 @@ public class AnalysisService {
      * @param user
      * @return
      */
-    @Transactional
     public Analysis createAnalysis(Record record, User user) {
 
         // MEMO 경험 기록이라면, CLOVA STUDIO를 이용해 요약 진행
@@ -56,7 +47,7 @@ public class AnalysisService {
 
         // Analysis 객체 생성 및 저장
         Analysis analysis = AnalysisConverter.toAnalysis(content, response.getComment(), record);
-        analysisRepository.save(analysis);
+        analysisDbService.saveAnalysis(analysis);
 
         // Ability 객체 생성 및 저장
         abilityService.parseAndSaveAbilities(response.getKeywordList(), analysis, user);
@@ -70,7 +61,6 @@ public class AnalysisService {
      * @param user
      * @return
      */
-    @Transactional
     public Analysis recreateAnalysis(Record record, User user) {
         Analysis analysis = record.getAnalysis();
 
@@ -81,8 +71,8 @@ public class AnalysisService {
         AnalysisAiResponse response = generateAbilityAnalysis(content);
 
         // Analysis 객체 수정
-        analysis.updateContent(content);
-        analysis.updateComment(response.getComment());
+        analysisDbService.updateAnalysisContent(analysis, content);
+        analysisDbService.updateAnalysisComment(analysis, response.getComment());
 
         // 기존 Ability 객체 삭제
         abilityService.deleteOriginAbilityList(analysis);
@@ -100,8 +90,8 @@ public class AnalysisService {
      * @return
      */
     public AnalysisResponse.AnalysisDto postAnalysis(Long userId, Long recordId) {
-        User user = findUserById(userId);
-        Record record = findRecordById(recordId);
+        User user = userDbService.findUserById(userId);
+        Record record = recordDbService.findRecordById(recordId);
 
         // User-Record 권한 유효성 검증
         validIsUserAuthorizedForRecord(user, record);
@@ -119,10 +109,9 @@ public class AnalysisService {
      * @param userId, analysisId
      * @return
      */
-    @Transactional(readOnly = true)
     public AnalysisResponse.AnalysisDto getAnalysis(Long userId, Long analysisId) {
-        User user = findUserById(userId);
-        Analysis analysis = findAnalysisById(analysisId);
+        User user = userDbService.findUserById(userId);
+        Analysis analysis = analysisDbService.findAnalysisById(analysisId);
 
         // User-Analysis 권한 유효성 검증
         validIsUserAuthorizedForAnalysis(user, analysis);
@@ -137,23 +126,23 @@ public class AnalysisService {
      */
     @Transactional
     public AnalysisResponse.AnalysisDto updateAnalysis(Long userId, AnalysisRequest.AnalysisUpdateDto analysisUpdateDto) {
-        User user = findUserById(userId);
-        Analysis analysis = findAnalysisById(analysisUpdateDto.getAnalysisId());
+        User user = userDbService.findUserById(userId);
+        Analysis analysis = analysisDbService.findAnalysisById(analysisUpdateDto.getAnalysisId());
 
         // User-Analysis 권한 유효성 검증
         validIsUserAuthorizedForAnalysis(user, analysis);
 
         // 경험 기록 제목 수정
         String title = analysisUpdateDto.getTitle();
-        analysis.getRecord().updateTitle(title);
+        recordDbService.updateRecordTitle(analysis.getRecord(), title);
 
         // 경험 역량 분석 요약 내용 수정
         String content = analysisUpdateDto.getContent();
-        analysis.updateContent(content);
+        analysisDbService.updateAnalysisContent(analysis, content);
 
         // 키워드 경험 내용 수정
         Map<String, String> abilityMap = analysisUpdateDto.getAbilityMap();
-        updateAbilityContents(analysis, abilityMap);
+        abilityService.updateAbilityContents(analysis, abilityMap);
 
         return AnalysisConverter.toAnalysisDto(analysis);
     }
@@ -164,13 +153,13 @@ public class AnalysisService {
      */
     @Transactional
     public void deleteAnalysis(Long userId, Long analysisId) {
-        User user = findUserById(userId);
-        Analysis analysis = findAnalysisById(analysisId);
+        User user = userDbService.findUserById(userId);
+        Analysis analysis = analysisDbService.findAnalysisById(analysisId);
 
         // User-Analysis 권한 유효성 검증
         validIsUserAuthorizedForAnalysis(user, analysis);
 
-        analysisRepository.delete(analysis);
+        analysisDbService.deleteAnalysis(analysis);
     }
 
     private AnalysisAiResponse generateAbilityAnalysis(String content) {
@@ -229,34 +218,4 @@ public class AnalysisService {
         }
     }
 
-    private void updateAbilityContents(Analysis analysis, Map<String, String> abilityMap) {
-        abilityMap.forEach((keyword, content) -> {
-            Keyword key = Keyword.getName(keyword);
-            Ability ability = findAbilityByKeyword(analysis, key);
-            ability.updateContent(content);
-        });
-    }
-
-    private Ability findAbilityByKeyword(Analysis analysis, Keyword key) {
-        // keyword가 기존 역량 분석에 존재했는지 확인
-        return analysis.getAbilityList().stream()
-                .filter(ability -> ability.getKeyword().equals(key))
-                .findFirst()
-                .orElseThrow(() -> new AbilityException(AbilityErrorStatus.INVALID_KEYWORD));
-    }
-
-    private User findUserById(Long userId) {
-        return userRepository.findById(userId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.UNAUTHORIZED));
-    }
-
-    private Analysis findAnalysisById(Long analysisId) {
-        return analysisRepository.findAnalysisById(analysisId)
-                .orElseThrow(() -> new AnalysisException(AnalysisErrorStatus.ANALYSIS_NOT_FOUND));
-    }
-
-    private Record findRecordById(Long recordId) {
-        return recordRepository.findRecordById(recordId)
-                .orElseThrow(() -> new RecordException(RecordErrorStatus.RECORD_NOT_FOUND));
-    }
 }

--- a/src/main/java/corecord/dev/domain/chat/application/ChatDbService.java
+++ b/src/main/java/corecord/dev/domain/chat/application/ChatDbService.java
@@ -6,7 +6,6 @@ import corecord.dev.domain.chat.domain.entity.ChatRoom;
 import corecord.dev.domain.chat.domain.repository.ChatRepository;
 import corecord.dev.domain.chat.domain.repository.ChatRoomRepository;
 import corecord.dev.domain.user.domain.entity.User;
-import corecord.dev.domain.user.domain.repository.UserRepository;
 import corecord.dev.domain.chat.exception.ChatException;
 import corecord.dev.domain.chat.status.ChatErrorStatus;
 import jakarta.transaction.Transactional;
@@ -21,7 +20,6 @@ public class ChatDbService {
 
     private final ChatRepository chatRepository;
     private final ChatRoomRepository chatRoomRepository;
-    private final UserRepository userRepository;
 
     @Transactional
     public ChatRoom createChatRoom(User user) {
@@ -35,33 +33,28 @@ public class ChatDbService {
         return chatRepository.save(chat);
     }
 
-    public ChatRoom findChatRoomById(Long chatRoomId, User user) {
-        return chatRoomRepository.findByChatRoomIdAndUser(chatRoomId, user)
-                .orElseThrow(() -> new ChatException(ChatErrorStatus.CHAT_ROOM_NOT_FOUND));
-    }
-
-    public User findUserById(Long userId) {
-        return userRepository.findById(userId)
-                .orElseThrow(() -> new ChatException(ChatErrorStatus.CHAT_ROOM_NOT_FOUND));
-    }
-
     @Transactional
     public void deleteChatRoom(ChatRoom chatRoom) {
         chatRepository.deleteByChatRoomId(chatRoom.getChatRoomId());
         chatRoomRepository.delete(chatRoom);
     }
 
+    @Transactional
+    public void deleteChatByUserId(Long userId) {
+        chatRepository.deleteChatByUserId(userId);
+    }
+
+    @Transactional
+    public void deleteChatRoomByUserId(Long userId) {
+        chatRoomRepository.deleteChatRoomByUserId(userId);
+    }
+
+    public ChatRoom findChatRoomById(Long chatRoomId, User user) {
+        return chatRoomRepository.findByChatRoomIdAndUser(chatRoomId, user)
+                .orElseThrow(() -> new ChatException(ChatErrorStatus.CHAT_ROOM_NOT_FOUND));
+    }
+
     public List<Chat> findChatsByChatRoom(ChatRoom chatRoom) {
         return chatRepository.findByChatRoomOrderByChatId(chatRoom);
-    }
-
-    @Transactional
-    public void updateUserTmpChat(User user, Long chatRoomId) {
-        user.updateTmpChat(chatRoomId);
-    }
-
-    @Transactional
-    public void deleteUserTmpChat(User user) {
-        user.deleteTmpChat();
     }
 }

--- a/src/main/java/corecord/dev/domain/folder/application/FolderDbService.java
+++ b/src/main/java/corecord/dev/domain/folder/application/FolderDbService.java
@@ -1,0 +1,52 @@
+package corecord.dev.domain.folder.application;
+
+import corecord.dev.domain.folder.domain.dto.response.FolderResponse;
+import corecord.dev.domain.folder.domain.entity.Folder;
+import corecord.dev.domain.folder.domain.repository.FolderRepository;
+import corecord.dev.domain.folder.exception.FolderException;
+import corecord.dev.domain.folder.status.FolderErrorStatus;
+import corecord.dev.domain.user.domain.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FolderDbService {
+    private final FolderRepository folderRepository;
+
+    @Transactional
+    public void saveFolder(Folder folder) {
+        folderRepository.save(folder);
+    }
+
+    @Transactional
+    public void deleteFolder(Folder folder) {
+        folderRepository.delete(folder);
+    }
+
+    @Transactional
+    public void deleteFolderByUserId(Long userId) {
+        folderRepository.deleteFolderByUserId(userId);
+    }
+
+    public Folder findFolderByTitle(User user, String title) {
+        return folderRepository.findFolderByTitle(title, user)
+                .orElseThrow(() -> new FolderException(FolderErrorStatus.FOLDER_NOT_FOUND));
+    }
+
+    public Folder findFolderById(Long folderId) {
+        return folderRepository.findById(folderId)
+                .orElseThrow(() -> new FolderException(FolderErrorStatus.FOLDER_NOT_FOUND));
+    }
+
+    public List<FolderResponse.FolderDto> findFolderDtoList(User user) {
+        return folderRepository.findFolderDtoList(user);
+    }
+
+    public boolean isFolderExist(String title) {
+        return folderRepository.existsByTitle(title);
+    }
+}

--- a/src/main/java/corecord/dev/domain/folder/application/FolderService.java
+++ b/src/main/java/corecord/dev/domain/folder/application/FolderService.java
@@ -1,16 +1,13 @@
 package corecord.dev.domain.folder.application;
 
-import corecord.dev.common.exception.GeneralException;
-import corecord.dev.common.status.ErrorStatus;
 import corecord.dev.domain.folder.domain.converter.FolderConverter;
 import corecord.dev.domain.folder.domain.dto.request.FolderRequest;
 import corecord.dev.domain.folder.domain.dto.response.FolderResponse;
 import corecord.dev.domain.folder.domain.entity.Folder;
 import corecord.dev.domain.folder.status.FolderErrorStatus;
 import corecord.dev.domain.folder.exception.FolderException;
-import corecord.dev.domain.folder.domain.repository.FolderRepository;
+import corecord.dev.domain.user.application.UserDbService;
 import corecord.dev.domain.user.domain.entity.User;
-import corecord.dev.domain.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -22,8 +19,8 @@ import java.util.List;
 @Slf4j
 @RequiredArgsConstructor
 public class FolderService {
-    private final FolderRepository folderRepository;
-    private final UserRepository userRepository;
+    private final FolderDbService folderDbService;
+    private final UserDbService userDbService;
 
     /*
      * 폴더명(title)을 request로 받아, 새로운 폴더를 생성 후 생성 순 풀더 리스트 반환
@@ -32,7 +29,7 @@ public class FolderService {
      */
     @Transactional
     public FolderResponse.FolderDtoList createFolder(Long userId, FolderRequest.FolderDto folderDto) {
-        User user = findUserById(userId);
+        User user = userDbService.findUserById(userId);
         String title = folderDto.getTitle();
 
         // 폴더명 유효성 검증
@@ -40,9 +37,9 @@ public class FolderService {
 
         // folder 객체 생성 및 User 연관관계 설정
         Folder folder = FolderConverter.toFolderEntity(title, user);
-        folderRepository.save(folder);
+        folderDbService.saveFolder(folder);
 
-        List<FolderResponse.FolderDto> folderList = folderRepository.findFolderDtoList(user);
+        List<FolderResponse.FolderDto> folderList = folderDbService.findFolderDtoList(user);
         return FolderConverter.toFolderDtoList(folderList);
     }
 
@@ -53,15 +50,15 @@ public class FolderService {
      */
     @Transactional
     public FolderResponse.FolderDtoList deleteFolder(Long userId, Long folderId) {
-        User user = findUserById(userId);
-        Folder folder = findFolderById(folderId);
+        User user = userDbService.findUserById(userId);
+        Folder folder = folderDbService.findFolderById(folderId);
 
         // User-Folder 권한 유효성 검증
         validIsUserAuthorizedForFolder(user, folder);
 
-        folderRepository.delete(folder);
+        folderDbService.deleteFolder(folder);
 
-        List<FolderResponse.FolderDto> folderList = folderRepository.findFolderDtoList(user);
+        List<FolderResponse.FolderDto> folderList = folderDbService.findFolderDtoList(user);
         return FolderConverter.toFolderDtoList(folderList);
     }
 
@@ -72,8 +69,8 @@ public class FolderService {
      */
     @Transactional
     public FolderResponse.FolderDtoList updateFolder(Long userId, FolderRequest.FolderUpdateDto folderDto) {
-        User user = findUserById(userId);
-        Folder folder = findFolderById(folderDto.getFolderId());
+        User user = userDbService.findUserById(userId);
+        Folder folder = folderDbService.findFolderById(folderDto.getFolderId());
         String title = folderDto.getTitle();
 
         // 폴더명 유효성 검증
@@ -84,7 +81,7 @@ public class FolderService {
 
         folder.updateTitle(title);
 
-        List<FolderResponse.FolderDto> folderList = folderRepository.findFolderDtoList(user);
+        List<FolderResponse.FolderDto> folderList = folderDbService.findFolderDtoList(user);
         return FolderConverter.toFolderDtoList(folderList);
     }
 
@@ -95,9 +92,9 @@ public class FolderService {
      */
     @Transactional(readOnly = true)
     public FolderResponse.FolderDtoList getFolderList(Long userId) {
-        User user = findUserById(userId);
+        User user = userDbService.findUserById(userId);
 
-        List<FolderResponse.FolderDto> folderList = folderRepository.findFolderDtoList(user);
+        List<FolderResponse.FolderDto> folderList = folderDbService.findFolderDtoList(user);
         return FolderConverter.toFolderDtoList(folderList);
     }
 
@@ -108,7 +105,7 @@ public class FolderService {
         }
 
         // 폴더명 중복 검사
-        if (folderRepository.existsByTitle(title)) {
+        if (folderDbService.isFolderExist(title)) {
             throw new FolderException(FolderErrorStatus.DUPLICATED_FOLDER_TITLE);
         }
     }
@@ -119,13 +116,4 @@ public class FolderService {
             throw new FolderException(FolderErrorStatus.USER_FOLDER_UNAUTHORIZED);
     }
 
-    private Folder findFolderById(Long folderId) {
-        return folderRepository.findById(folderId)
-                .orElseThrow(() -> new FolderException(FolderErrorStatus.FOLDER_NOT_FOUND));
-    }
-
-    private User findUserById(Long userId) {
-        return userRepository.findById(userId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.UNAUTHORIZED));
-    }
 }

--- a/src/main/java/corecord/dev/domain/record/application/RecordDbService.java
+++ b/src/main/java/corecord/dev/domain/record/application/RecordDbService.java
@@ -1,0 +1,79 @@
+package corecord.dev.domain.record.application;
+
+import corecord.dev.domain.ability.domain.entity.Keyword;
+import corecord.dev.domain.folder.domain.entity.Folder;
+import corecord.dev.domain.record.domain.entity.Record;
+import corecord.dev.domain.record.domain.repository.RecordRepository;
+import corecord.dev.domain.record.exception.RecordException;
+import corecord.dev.domain.record.status.RecordErrorStatus;
+import corecord.dev.domain.user.domain.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RecordDbService {
+    private final RecordRepository recordRepository;
+
+    private final int listSize = 30;
+
+    @Transactional
+    public Record saveRecord(Record record) {
+        return recordRepository.save(record);
+    }
+
+    @Transactional
+    public void deleteRecord(Record record) {
+        recordRepository.delete(record);
+    }
+
+    @Transactional
+    public void deleteRecordByUserId(Long userId) {
+        recordRepository.deleteRecordByUserId(userId);
+    }
+
+    public int getRecordCount(User user) {
+        return recordRepository.getRecordCount(user);
+    }
+
+    @Transactional
+    public void updateRecordTitle(Record record, String title) {
+        record.updateTitle(title);
+    }
+
+    public Record findRecordById(Long recordId) {
+        return recordRepository.findRecordById(recordId)
+                .orElseThrow(() -> new RecordException(RecordErrorStatus.RECORD_NOT_FOUND));
+    }
+
+    public Record findTmpRecordById(Long recordId) {
+        return recordRepository.findById(recordId)
+                .orElseThrow(() -> new RecordException(RecordErrorStatus.RECORD_NOT_FOUND));
+    }
+
+    public List<Record> findRecordListByFolder(User user, Folder folder, Long lastRecordId) {
+        Pageable pageable = PageRequest.of(0, listSize + 1, Sort.by("createdAt").descending());
+        return recordRepository.findRecordsByFolder(folder, user, lastRecordId, pageable);
+    }
+
+    public List<Record> findRecordList(User user, Long lastRecordId) {
+        Pageable pageable = PageRequest.of(0, listSize + 1, Sort.by("createdAt").descending());
+        return recordRepository.findRecords(user, lastRecordId, pageable);
+    }
+
+    public List<Record> findRecordListOrderByCreatedAt(User user) {
+        Pageable pageable = PageRequest.of(0, 6, Sort.by("createdAt").descending());
+        return recordRepository.findRecordsOrderByCreatedAt(user, pageable);
+    }
+
+    public List<Record> findRecordListByKeyword(User user, Keyword keyword, Long lastRecordId) {
+        Pageable pageable = PageRequest.of(0, listSize + 1, Sort.by("createdAt").descending());
+        return recordRepository.findRecordsByKeyword(keyword, user, lastRecordId, pageable);
+    }
+}

--- a/src/main/java/corecord/dev/domain/user/application/UserDbService.java
+++ b/src/main/java/corecord/dev/domain/user/application/UserDbService.java
@@ -1,0 +1,50 @@
+package corecord.dev.domain.user.application;
+
+import corecord.dev.common.exception.GeneralException;
+import corecord.dev.common.status.ErrorStatus;
+import corecord.dev.domain.user.domain.entity.User;
+import corecord.dev.domain.user.domain.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserDbService {
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void updateUserTmpChat(User user, Long chatRoomId) {
+        user.updateTmpChat(chatRoomId);
+    }
+
+    @Transactional
+    public void deleteUserTmpChat(User user) {
+        user.deleteTmpChat();
+    }
+
+    @Transactional
+    public void deleteUserByUserId(Long userId) {
+        userRepository.deleteUserByUserId(userId);
+    }
+
+    @Transactional
+    public User saveUser(User user) {
+        return userRepository.save(user);
+    }
+
+    public boolean IsUserExistByProviderId(String providerId) {
+        return userRepository.existsByProviderId(providerId);
+    }
+
+    public User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.UNAUTHORIZED));
+    }
+
+    public User findUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.UNAUTHORIZED));
+    }
+
+}

--- a/src/test/java/corecord/dev/ability/service/AbilityServiceTest.java
+++ b/src/test/java/corecord/dev/ability/service/AbilityServiceTest.java
@@ -1,19 +1,19 @@
 package corecord.dev.ability.service;
 
+import corecord.dev.domain.ability.application.AbilityDbService;
 import corecord.dev.domain.ability.domain.dto.response.AbilityResponse;
 import corecord.dev.domain.ability.domain.entity.Ability;
 import corecord.dev.domain.ability.domain.entity.Keyword;
 import corecord.dev.domain.ability.status.AbilityErrorStatus;
 import corecord.dev.domain.ability.exception.AbilityException;
-import corecord.dev.domain.ability.domain.repository.AbilityRepository;
 import corecord.dev.domain.ability.application.AbilityService;
 import corecord.dev.domain.analysis.domain.entity.Analysis;
 import corecord.dev.domain.folder.domain.entity.Folder;
 import corecord.dev.domain.record.domain.entity.RecordType;
 import corecord.dev.domain.record.domain.entity.Record;
+import corecord.dev.domain.user.application.UserDbService;
 import corecord.dev.domain.user.domain.entity.Status;
 import corecord.dev.domain.user.domain.entity.User;
-import corecord.dev.domain.user.domain.repository.UserRepository;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -37,13 +37,13 @@ import static org.mockito.Mockito.*;
 public class AbilityServiceTest {
 
     @Mock
-    EntityManager entityManager;
+    private EntityManager entityManager;
 
     @Mock
-    UserRepository userRepository;
+    private UserDbService userDbService;
 
     @Mock
-    AbilityRepository abilityRepository;
+    private AbilityDbService abilityDbService;
 
     @InjectMocks
     AbilityService abilityService;
@@ -72,16 +72,16 @@ public class AbilityServiceTest {
         analysis.addAbility(ability1);
         analysis.addAbility(ability2);
 
-        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-        when(abilityRepository.getKeywordList(any(User.class)))
-                .thenReturn(List.of(Keyword.COMMUNICATION, Keyword.LEADERSHIP));
+        when(userDbService.findUserById(1L)).thenReturn(user);
+        when(abilityDbService.findKeywordList(any(User.class)))
+                .thenReturn(List.of(Keyword.COMMUNICATION.getValue(), Keyword.LEADERSHIP.getValue()));
 
         // When
         AbilityResponse.KeywordListDto response = abilityService.getKeywordList(1L);
 
         // Then
-        verify(userRepository, times(1)).findById(1L);
-        verify(abilityRepository, times(1)).getKeywordList(user);
+        verify(userDbService, times(1)).findUserById(1L);
+        verify(abilityDbService, times(1)).findKeywordList(user);
 
         assertEquals(2, response.getKeywordList().size());
         assertEquals(Keyword.COMMUNICATION.getValue(), response.getKeywordList().get(0));
@@ -100,7 +100,7 @@ public class AbilityServiceTest {
         abilityService.parseAndSaveAbilities(keywordList, analysis, user);
 
         // Then
-        verify(abilityRepository, times(2)).save(any(Ability.class));
+        verify(abilityDbService, times(2)).saveAbility(any(Ability.class));
         assertEquals(2, analysis.getAbilityList().size());
         assertEquals(Keyword.COMMUNICATION.getValue(), analysis.getAbilityList().get(0).getKeyword().getValue());
         assertEquals(Keyword.LEADERSHIP.getValue(), analysis.getAbilityList().get(1).getKeyword().getValue());

--- a/src/test/java/corecord/dev/chat/service/ChatServiceTest.java
+++ b/src/test/java/corecord/dev/chat/service/ChatServiceTest.java
@@ -9,6 +9,7 @@ import corecord.dev.domain.chat.domain.entity.ChatRoom;
 import corecord.dev.domain.chat.exception.ChatException;
 import corecord.dev.domain.chat.infra.clova.application.ClovaService;
 import corecord.dev.domain.chat.infra.clova.dto.request.ClovaRequest;
+import corecord.dev.domain.user.application.UserDbService;
 import corecord.dev.domain.user.domain.entity.Status;
 import corecord.dev.domain.user.domain.entity.User;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,11 +21,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.lang.reflect.Field;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -37,6 +36,9 @@ class ChatServiceTest {
 
     @Mock
     private ChatDbService chatDbService;
+
+    @Mock
+    private UserDbService userDbService;
 
     @Mock
     private ClovaService clovaService;
@@ -54,7 +56,7 @@ class ChatServiceTest {
     @DisplayName("채팅방 생성 테스트")
     void createChatRoom() {
         // Given
-        when(chatDbService.findUserById(user.getUserId())).thenReturn(user);
+        when(userDbService.findUserById(user.getUserId())).thenReturn(user);
         when(chatDbService.createChatRoom(user)).thenReturn(chatRoom);
         when(chatDbService.saveChat(anyInt(), anyString(), any(ChatRoom.class)))
                 .thenAnswer(invocation -> createTestChat(invocation.getArgument(1), invocation.getArgument(0)));
@@ -75,7 +77,7 @@ class ChatServiceTest {
         Chat userChat = createTestChat("userChat", 1);
         Chat aiChat = createTestChat("aiChat", 0);
 
-        when(chatDbService.findUserById(user.getUserId())).thenReturn(user);
+        when(userDbService.findUserById(user.getUserId())).thenReturn(user);
         when(chatDbService.findChatRoomById(chatRoom.getChatRoomId(), user)).thenReturn(chatRoom);
         when(chatDbService.findChatsByChatRoom(chatRoom)).thenReturn(List.of(userChat, aiChat));
 
@@ -101,7 +103,7 @@ class ChatServiceTest {
                     .content("어떤 경험을 말해야 할지 모르겠어요.")
                     .build();
 
-            when(chatDbService.findUserById(user.getUserId())).thenReturn(user);
+            when(userDbService.findUserById(user.getUserId())).thenReturn(user);
             when(chatDbService.findChatRoomById(chatRoom.getChatRoomId(), user)).thenReturn(chatRoom);
             when(chatDbService.saveChat(anyInt(), anyString(), any(ChatRoom.class)))
                     .thenAnswer(invocation -> createTestChat(invocation.getArgument(1), invocation.getArgument(0)));
@@ -128,7 +130,7 @@ class ChatServiceTest {
                     .content("테스트 입력")
                     .build();
 
-            when(chatDbService.findUserById(user.getUserId())).thenReturn(user);
+            when(userDbService.findUserById(user.getUserId())).thenReturn(user);
             when(chatDbService.findChatRoomById(chatRoom.getChatRoomId(), user)).thenReturn(chatRoom);
             when(chatDbService.saveChat(anyInt(), anyString(), any(ChatRoom.class)))
                     .thenAnswer(invocation -> createTestChat(invocation.getArgument(1), invocation.getArgument(0)));
@@ -162,7 +164,7 @@ class ChatServiceTest {
                     createTestChat("userChat2", 1)
             );
 
-            when(chatDbService.findUserById(user.getUserId())).thenReturn(user);
+            when(userDbService.findUserById(user.getUserId())).thenReturn(user);
             when(chatDbService.findChatRoomById(chatRoom.getChatRoomId(), user)).thenReturn(chatRoom);
             when(chatDbService.findChatsByChatRoom(chatRoom)).thenReturn(chatList);
             when(clovaService.generateAiResponse(any(ClovaRequest.class)))
@@ -185,7 +187,7 @@ class ChatServiceTest {
                     createTestChat("aiChat1", 0)
             );
 
-            when(chatDbService.findUserById(user.getUserId())).thenReturn(user);
+            when(userDbService.findUserById(user.getUserId())).thenReturn(user);
             when(chatDbService.findChatRoomById(chatRoom.getChatRoomId(), user)).thenReturn(chatRoom);
             when(chatDbService.findChatsByChatRoom(chatRoom)).thenReturn(chatList);
             when(clovaService.generateAiResponse(any(ClovaRequest.class)))
@@ -205,7 +207,7 @@ class ChatServiceTest {
             );
 
             String longTitle = "a".repeat(51); // 51자 제목 생성
-            when(chatDbService.findUserById(user.getUserId())).thenReturn(user);
+            when(userDbService.findUserById(user.getUserId())).thenReturn(user);
             when(chatDbService.findChatRoomById(chatRoom.getChatRoomId(), user)).thenReturn(chatRoom);
             when(chatDbService.findChatsByChatRoom(chatRoom)).thenReturn(chatList);
             when(clovaService.generateAiResponse(any(ClovaRequest.class)))
@@ -225,7 +227,7 @@ class ChatServiceTest {
             );
 
             String longContent = "a".repeat(501); // 501자 응답 생성
-            when(chatDbService.findUserById(user.getUserId())).thenReturn(user);
+            when(userDbService.findUserById(user.getUserId())).thenReturn(user);
             when(chatDbService.findChatRoomById(chatRoom.getChatRoomId(), user)).thenReturn(chatRoom);
             when(chatDbService.findChatsByChatRoom(chatRoom)).thenReturn(chatList);
             when(clovaService.generateAiResponse(any(ClovaRequest.class)))
@@ -244,16 +246,16 @@ class ChatServiceTest {
         @DisplayName("저장 성공")
         void saveChatTmp() {
             // Given
-            when(chatDbService.findUserById(user.getUserId())).thenReturn(user);
+            when(userDbService.findUserById(user.getUserId())).thenReturn(user);
             when(chatDbService.findChatRoomById(chatRoom.getChatRoomId(), user)).thenReturn(chatRoom);
 
             // When
             chatService.saveChatTmp(user.getUserId(), chatRoom.getChatRoomId());
 
             // Then
-            verify(chatDbService).findUserById(user.getUserId());
+            verify(userDbService).findUserById(user.getUserId());
             verify(chatDbService).findChatRoomById(chatRoom.getChatRoomId(), user);
-            verify(chatDbService).updateUserTmpChat(user, chatRoom.getChatRoomId());
+            verify(userDbService).updateUserTmpChat(user, chatRoom.getChatRoomId());
         }
 
         @Test
@@ -261,7 +263,7 @@ class ChatServiceTest {
         void saveChatTmpFailsWhenTmpChatExists() {
             // Given
             user.updateTmpChat(chatRoom.getChatRoomId());
-            when(chatDbService.findUserById(user.getUserId())).thenReturn(user);
+            when(userDbService.findUserById(user.getUserId())).thenReturn(user);
             when(chatDbService.findChatRoomById(chatRoom.getChatRoomId(), user)).thenReturn(chatRoom);
 
             // When & Then
@@ -273,7 +275,7 @@ class ChatServiceTest {
         void getChatTmp() {
             // Given
             user.updateTmpChat(chatRoom.getChatRoomId());
-            when(chatDbService.findUserById(user.getUserId())).thenReturn(user);
+            when(userDbService.findUserById(user.getUserId())).thenReturn(user);
 
             // When
             ChatResponse.ChatTmpDto result = chatService.getChatTmp(user.getUserId());
@@ -281,7 +283,7 @@ class ChatServiceTest {
             // Then
             assertEquals(result.getChatRoomId(), chatRoom.getChatRoomId());
             assertTrue(result.isExist());
-            verify(chatDbService).findUserById(user.getUserId());
+            verify(userDbService).findUserById(user.getUserId());
         }
     }
 


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #103 

### 💡 작업내용
- **도메인별 DB Service 생성**
  - 각 도메인의 DB update와 관련된 모든 작업은 dbService에서 수행
  - ex) recordDbService -> record entity의 저장, 수정, 삭제, 조회 함수 수행
  - recordService에서 user의 정보를 가져와야 한다면, `userDbService.findById()` 함수를 사용해 수행   
- **도메인별 각 Repository는 각 도메인의 dbService에서만 접근하도록 리팩토링 수행**
  - service단의 중복 코드 감소,  유지보수성 증가
- **openAI 호출 코드와 transaction이 필요한 db 관련 코드 분리**
  - analysisService에서 analysisDbService, openAiService를 호출
  - openAiSerevice -> 외부 API 호출
  - analysisDbService -> 결과에 대해 파싱된 값을 저장 및 수정 + `@Transaction` 사용  

### 📸 스크린샷(선택)
![스크린샷 2024-11-21 오후 6 30 45](https://github.com/user-attachments/assets/8b8579dc-8e69-43e5-978f-8853645af19c)
![스크린샷 2024-11-21 오후 6 31 45](https://github.com/user-attachments/assets/09e6901a-1654-4912-8b6d-3b7d1aad9106)


### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
