### PR TITLE
[Chore/#110] 경험 기록 내용이 충분하지 않을 시 Error 반환

### DIFF
--- a/src/main/java/corecord/dev/domain/analysis/application/AnalysisService.java
+++ b/src/main/java/corecord/dev/domain/analysis/application/AnalysisService.java
@@ -173,6 +173,8 @@ public class AnalysisService {
 
     private String generateMemoSummary(String content) {
         String response = openAiService.generateMemoSummary(content);
+
+        validIsRecordEnough(response);
         validAnalysisContentLength(response);
 
         return response;
@@ -186,6 +188,11 @@ public class AnalysisService {
         validAnalysisContentLength(content);
 
         return content;
+    }
+
+    private void validIsRecordEnough(String response) {
+        if (response.contains("NO_RECORD"))
+            throw new RecordException(RecordErrorStatus.NO_RECORD);
     }
 
     private void validIsUserAuthorizedForAnalysis(User user, Analysis analysis) {

--- a/src/main/java/corecord/dev/domain/record/application/RecordService.java
+++ b/src/main/java/corecord/dev/domain/record/application/RecordService.java
@@ -53,10 +53,10 @@ public class RecordService {
 
         // 경험 기록 종류에 따른 Record 생성
         Record record = createRecordBasedOnType(recordDto, user, folder);
-        recordDbService.saveRecord(record);
 
         // 역량 분석 레포트 생성
         analysisService.createAnalysis(record, user);
+        recordDbService.saveRecord(record);
 
         return RecordConverter.toMemoRecordDto(record);
     }

--- a/src/main/java/corecord/dev/domain/record/status/RecordErrorStatus.java
+++ b/src/main/java/corecord/dev/domain/record/status/RecordErrorStatus.java
@@ -13,7 +13,8 @@ public enum RecordErrorStatus implements BaseErrorStatus {
     NOT_ENOUGH_MEMO_RECORD_CONTENT(HttpStatus.BAD_REQUEST, "E0400_NOT_ENOUGH_CONTENT", "메모 내용은 30자 이상이어야 합니다."),
     USER_RECORD_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "E401_RECORD_UNAUTHORIZED", "유저가 경험 기록에 대한 권한이 없습니다."),
     RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "E0404_RECORD", "존재하지 않는 경험 기록입니다."),
-    ALREADY_TMP_MEMO(HttpStatus.BAD_REQUEST, "E0400_TMP_MEMO", "유저가 이미 임시 저장된 메모를 가지고 있습니다.")
+    ALREADY_TMP_MEMO(HttpStatus.BAD_REQUEST, "E0400_TMP_MEMO", "유저가 이미 임시 저장된 메모를 가지고 있습니다."),
+    NO_RECORD(HttpStatus.BAD_REQUEST, "E0400_NO_RECORD", "경험 기록의 내용이 충분하지 않습니다.")
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #110 

### 💡 작업내용
- 분석할 경험 기록 내용이 충분하지 않을 시 Error 반환
- ErrorStatus 추가
- 경험 기록 및 역량 분석 플로우 변경
  - 기존 : 경험 기록 저장 -> 역량 분석 및 Analysis 저장
  - 변경 : 경험 기록 entity 작성 -> 역량 분석 및 Analysis 저장 -> Record 저장

### 📸 스크린샷(선택)
<img width="988" alt="스크린샷 2024-11-25 오후 2 37 22" src="https://github.com/user-attachments/assets/62cac7fe-8449-494c-9111-196c8090ef2f">


### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
