### PR TITLE
[Refactor/#106] 폴더 삭제 기능 쿼리 개선

### DIFF
--- a/src/main/java/corecord/dev/domain/ability/application/AbilityDbService.java
+++ b/src/main/java/corecord/dev/domain/ability/application/AbilityDbService.java
@@ -4,6 +4,7 @@ import corecord.dev.domain.ability.domain.dto.response.AbilityResponse;
 import corecord.dev.domain.ability.domain.entity.Ability;
 import corecord.dev.domain.ability.domain.entity.Keyword;
 import corecord.dev.domain.ability.domain.repository.AbilityRepository;
+import corecord.dev.domain.folder.domain.entity.Folder;
 import corecord.dev.domain.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,6 +25,11 @@ public class AbilityDbService {
     @Transactional
     public void deleteAbilityByUserId(Long userId) {
         abilityRepository.deleteAbilityByUserId(userId);
+    }
+
+    @Transactional
+    public void deleteAbilityByFolder(Folder folder) {
+        abilityRepository.deleteAbilityByFolder(folder);
     }
 
     @Transactional

--- a/src/main/java/corecord/dev/domain/ability/domain/repository/AbilityRepository.java
+++ b/src/main/java/corecord/dev/domain/ability/domain/repository/AbilityRepository.java
@@ -3,6 +3,7 @@ package corecord.dev.domain.ability.domain.repository;
 import corecord.dev.domain.ability.domain.dto.response.AbilityResponse;
 import corecord.dev.domain.ability.domain.entity.Ability;
 import corecord.dev.domain.ability.domain.entity.Keyword;
+import corecord.dev.domain.folder.domain.entity.Folder;
 import corecord.dev.domain.user.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -28,6 +29,12 @@ public interface AbilityRepository extends JpaRepository<Ability, Long> {
                 "FROM Ability a " +
                 "WHERE a.user.userId IN :userId")
         void deleteAbilityByUserId(@Param(value = "userId") Long userId);
+
+        @Modifying
+        @Query("DELETE " +
+                "FROM Ability a " +
+                "WHERE a.analysis.record.folder = :folder")
+        void deleteAbilityByFolder(@Param(value = "folder") Folder folder);
 
         @Query("SELECT distinct a.keyword AS keyword " + // unique한 keyword list 반환
                 "FROM Ability a " +

--- a/src/main/java/corecord/dev/domain/analysis/application/AnalysisDbService.java
+++ b/src/main/java/corecord/dev/domain/analysis/application/AnalysisDbService.java
@@ -4,6 +4,7 @@ import corecord.dev.domain.analysis.domain.entity.Analysis;
 import corecord.dev.domain.analysis.domain.repository.AnalysisRepository;
 import corecord.dev.domain.analysis.exception.AnalysisException;
 import corecord.dev.domain.analysis.status.AnalysisErrorStatus;
+import corecord.dev.domain.folder.domain.entity.Folder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,9 +40,13 @@ public class AnalysisDbService {
         analysisRepository.deleteAnalysisByUserId(userId);
     }
 
+    @Transactional
+    public void deleteAnalysisByFolder(Folder folder) {
+        analysisRepository.deleteAnalysisByFolder(folder);
+    }
+
     public Analysis findAnalysisById(Long analysisId) {
         return analysisRepository.findAnalysisById(analysisId)
                 .orElseThrow(() -> new AnalysisException(AnalysisErrorStatus.ANALYSIS_NOT_FOUND));
     }
-
 }

--- a/src/main/java/corecord/dev/domain/analysis/domain/repository/AnalysisRepository.java
+++ b/src/main/java/corecord/dev/domain/analysis/domain/repository/AnalysisRepository.java
@@ -1,6 +1,7 @@
 package corecord.dev.domain.analysis.domain.repository;
 
 import corecord.dev.domain.analysis.domain.entity.Analysis;
+import corecord.dev.domain.folder.domain.entity.Folder;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -25,4 +26,10 @@ public interface AnalysisRepository extends JpaRepository<Analysis, Long> {
             "FROM Analysis a " +
             "WHERE a.record.user.userId IN :userId")
     void deleteAnalysisByUserId(@Param(value = "userId") Long userId);
+
+    @Modifying
+    @Query("DELETE " +
+            "FROM Analysis a " +
+            "WHERE a.record.folder = :folder")
+    void deleteAnalysisByFolder(@Param(value = "folder") Folder folder);
 }

--- a/src/main/java/corecord/dev/domain/chat/application/ChatDbService.java
+++ b/src/main/java/corecord/dev/domain/chat/application/ChatDbService.java
@@ -5,6 +5,7 @@ import corecord.dev.domain.chat.domain.entity.Chat;
 import corecord.dev.domain.chat.domain.entity.ChatRoom;
 import corecord.dev.domain.chat.domain.repository.ChatRepository;
 import corecord.dev.domain.chat.domain.repository.ChatRoomRepository;
+import corecord.dev.domain.folder.domain.entity.Folder;
 import corecord.dev.domain.user.domain.entity.User;
 import corecord.dev.domain.chat.exception.ChatException;
 import corecord.dev.domain.chat.status.ChatErrorStatus;
@@ -47,6 +48,11 @@ public class ChatDbService {
     @Transactional
     public void deleteChatRoomByUserId(Long userId) {
         chatRoomRepository.deleteChatRoomByUserId(userId);
+    }
+
+    @Transactional
+    public void deleteChatRoomByFolder(Folder folder) {
+        chatRepository.deleteChatByFolderId(folder.getFolderId());
     }
 
     public ChatRoom findChatRoomById(Long chatRoomId, User user) {

--- a/src/main/java/corecord/dev/domain/chat/domain/repository/ChatRepository.java
+++ b/src/main/java/corecord/dev/domain/chat/domain/repository/ChatRepository.java
@@ -23,4 +23,14 @@ public interface ChatRepository extends JpaRepository<Chat, Long> {
             "FROM Chat c " +
             "WHERE c.chatRoom.user.userId IN :userId")
     void deleteChatByUserId(@Param(value = "userId") Long userId);
+
+    @Modifying
+    @Query(value = "DELETE c, cr, r " +
+            "FROM chat c " +
+            "JOIN chat_room cr ON cr.chat_room_id = c.chat_room_id " +
+            "JOIN Record r ON r.chat_room_id = cr.chat_room_id " +
+            "WHERE r.folder_id = :folderId ",
+            nativeQuery = true)
+    void deleteChatByFolderId(@Param(value = "folderId") Long folderId);
+
 }

--- a/src/main/java/corecord/dev/domain/chat/domain/repository/ChatRoomRepository.java
+++ b/src/main/java/corecord/dev/domain/chat/domain/repository/ChatRoomRepository.java
@@ -2,7 +2,6 @@ package corecord.dev.domain.chat.domain.repository;
 
 import corecord.dev.domain.chat.domain.entity.ChatRoom;
 import corecord.dev.domain.user.domain.entity.User;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/corecord/dev/domain/folder/application/FolderDbService.java
+++ b/src/main/java/corecord/dev/domain/folder/application/FolderDbService.java
@@ -24,7 +24,7 @@ public class FolderDbService {
 
     @Transactional
     public void deleteFolder(Folder folder) {
-        folderRepository.delete(folder.getFolderId());
+        folderRepository.delete(folder);
     }
 
     @Transactional

--- a/src/main/java/corecord/dev/domain/folder/application/FolderDbService.java
+++ b/src/main/java/corecord/dev/domain/folder/application/FolderDbService.java
@@ -24,7 +24,7 @@ public class FolderDbService {
 
     @Transactional
     public void deleteFolder(Folder folder) {
-        folderRepository.delete(folder);
+        folderRepository.delete(folder.getFolderId());
     }
 
     @Transactional

--- a/src/main/java/corecord/dev/domain/folder/application/FolderService.java
+++ b/src/main/java/corecord/dev/domain/folder/application/FolderService.java
@@ -1,11 +1,15 @@
 package corecord.dev.domain.folder.application;
 
+import corecord.dev.domain.ability.application.AbilityDbService;
+import corecord.dev.domain.analysis.application.AnalysisDbService;
+import corecord.dev.domain.chat.application.ChatDbService;
 import corecord.dev.domain.folder.domain.converter.FolderConverter;
 import corecord.dev.domain.folder.domain.dto.request.FolderRequest;
 import corecord.dev.domain.folder.domain.dto.response.FolderResponse;
 import corecord.dev.domain.folder.domain.entity.Folder;
 import corecord.dev.domain.folder.status.FolderErrorStatus;
 import corecord.dev.domain.folder.exception.FolderException;
+import corecord.dev.domain.record.application.RecordDbService;
 import corecord.dev.domain.user.application.UserDbService;
 import corecord.dev.domain.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +25,11 @@ import java.util.List;
 public class FolderService {
     private final FolderDbService folderDbService;
     private final UserDbService userDbService;
+    private final AnalysisDbService analysisDbService;
+    private final AbilityDbService abilityDbService;
+    private final ChatDbService chatDbService;
+    private final RecordDbService recordDbService;
+
 
     /*
      * 폴더명(title)을 request로 받아, 새로운 폴더를 생성 후 생성 순 풀더 리스트 반환
@@ -56,6 +65,10 @@ public class FolderService {
         // User-Folder 권한 유효성 검증
         validIsUserAuthorizedForFolder(user, folder);
 
+        abilityDbService.deleteAbilityByFolder(folder);
+        analysisDbService.deleteAnalysisByFolder(folder);
+        chatDbService.deleteChatRoomByFolder(folder);
+        recordDbService.deleteRecordByFolder(folder);
         folderDbService.deleteFolder(folder);
 
         List<FolderResponse.FolderDto> folderList = folderDbService.findFolderDtoList(user);

--- a/src/main/java/corecord/dev/domain/folder/domain/repository/FolderRepository.java
+++ b/src/main/java/corecord/dev/domain/folder/domain/repository/FolderRepository.java
@@ -3,6 +3,7 @@ package corecord.dev.domain.folder.domain.repository;
 import corecord.dev.domain.folder.domain.dto.response.FolderResponse;
 import corecord.dev.domain.folder.domain.entity.Folder;
 import corecord.dev.domain.user.domain.entity.User;
+import jakarta.validation.Valid;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -36,5 +37,10 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
             "WHERE f.user.userId IN :userId")
     void deleteFolderByUserId(@Param(value = "userId") Long userId);
 
-    void delete(Long folderId);
+
+    @Modifying
+    @Query("DELETE " +
+            "FROM Folder f " +
+            "WHERE f = :folder")
+    void delete(@Param(value = "folder") Folder folder);
 }

--- a/src/main/java/corecord/dev/domain/folder/domain/repository/FolderRepository.java
+++ b/src/main/java/corecord/dev/domain/folder/domain/repository/FolderRepository.java
@@ -35,4 +35,6 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
             "FROM Folder f " +
             "WHERE f.user.userId IN :userId")
     void deleteFolderByUserId(@Param(value = "userId") Long userId);
+
+    void delete(Long folderId);
 }

--- a/src/main/java/corecord/dev/domain/record/application/RecordDbService.java
+++ b/src/main/java/corecord/dev/domain/record/application/RecordDbService.java
@@ -38,6 +38,11 @@ public class RecordDbService {
         recordRepository.deleteRecordByUserId(userId);
     }
 
+    @Transactional
+    public void deleteRecordByFolder(Folder folder) {
+        recordRepository.deleteRecordByFolder(folder);
+    }
+
     public int getRecordCount(User user) {
         return recordRepository.getRecordCount(user);
     }

--- a/src/main/java/corecord/dev/domain/record/domain/repository/RecordRepository.java
+++ b/src/main/java/corecord/dev/domain/record/domain/repository/RecordRepository.java
@@ -86,4 +86,10 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
             "FROM Record r " +
             "WHERE r.user.userId IN :userId")
     void deleteRecordByUserId(@Param(value = "userId") Long userId);
+
+    @Modifying
+    @Query("DELETE " +
+            "FROM Record r " +
+            "WHERE r.folder = :folder")
+    void deleteRecordByFolder(@Param(value = "folder") Folder folder);
 }


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #106

### 💡 작업내용
- `@Modifying`annotation을 사용해 각 entity 삭제 작업 수행
- `Ability` -> `Analysis` -> `Chat` -> `Record` -> `Folder` 순으로 명시적 삭제 진행
- `ChatRoom` entity에서 직접적으로 `Record` 및 `Folder`에 접근할 수 없음
  - ChatRepository에서 `nativeQuery`를 이용해 `Chat`, `ChatRoom`, 이와 관련된 `Record` 삭제 작업 수행  

### 📸 스크린샷(선택)
**[ 수정 이전 폴더 삭제 시 실행되는 쿼리 ]**
- 3개의 MEMO type Record 저장
- 채팅까지 수행했다면 +@..
![스크린샷 2024-11-26 오후 2 15 21](https://github.com/user-attachments/assets/896b36c3-2e28-4190-b180-0f1341e49ab2)


**[ 수정 이후 폴더 삭제 시 실행되는 쿼리 ]**
- 2번의 채팅 및 CHAT Type Record
![스크린샷 2024-11-26 오후 4 46 26](https://github.com/user-attachments/assets/e79ee7cf-2c21-4f32-837c-3696c5962a43)


### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
- 조금 더 한 번에 쫘악 삭제하고 싶은데 어떻게 해야 더 효율적일지 고민입니다 .. 
